### PR TITLE
refactor(cz): use FILE metavar for --config-file option

### DIFF
--- a/dist/cz/bin/cz
+++ b/dist/cz/bin/cz
@@ -116,8 +116,7 @@ Usage: cz [options...] [command] [arguments...]
 Conventional commit message builder
 
 Options:
-  -c, --config-file CONFIG_FILE 
-                              Config file path
+  -c, --config-file FILE      Config file path
   -q, --quiet                 Suppress warnings and non-essential output
   -h, --help                  
   -V, --version               

--- a/scripts/cz/options.sh
+++ b/scripts/cz/options.sh
@@ -9,7 +9,7 @@ parser_definition() {
 		"Usage: cz [options...] [command] [arguments...]"
 	msg -- '' 'Conventional commit message builder' ''
 	msg -- 'Options:'
-	param   CONFIG_FILE  -c --config-file -- "Config file path"
+	param   CONFIG_FILE  -c --config-file var:FILE -- "Config file path"
 	flag    QUIET        -q --quiet       -- "Suppress warnings and non-essential output"
 	disp    :usage       -h --help
 	disp    VERSION      -V --version


### PR DESCRIPTION
## Summary

Changes help output metavar from `CONFIG_FILE` to `FILE` for consistency with Unix conventions.

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)