### PR TITLE
docs: add missing short options to manpages

### DIFF
--- a/dist/cz/man/man1/cz.1
+++ b/dist/cz/man/man1/cz.1
@@ -142,7 +142,7 @@ Suppress warnings and non\-essential output.
 Display usage information and exit.
 .RE
 .sp
-\fB\-\-version\fP
+\fB\-V\fP, \fB\-\-version\fP
 .RS 4
 Display version information and exit.
 .RE

--- a/dist/dotenv/man/man1/dotenv.1
+++ b/dist/dotenv/man/man1/dotenv.1
@@ -48,7 +48,7 @@ The .env file format follows common conventions. For detailed syntax
 information, see \fBenv\fP(5).
 .SH "OPTIONS"
 .sp
-\fB\-e\fP \fIFILE\fP
+\fB\-e\fP, \fB\-\-env\-file\fP \fIFILE\fP
 .RS 4
 Specify .env file to load. Can be specified multiple times to load multiple
 files. If not specified, defaults to \fB.env\fP. Files are processed in order,
@@ -75,6 +75,11 @@ Suppress warning messages. Does not affect error behavior.
 \fB\-h\fP, \fB\-\-help\fP
 .RS 4
 Show help message and exit.
+.RE
+.sp
+\fB\-V\fP, \fB\-\-version\fP
+.RS 4
+Show version information and exit.
 .RE
 .SH "ARGUMENTS"
 .sp

--- a/dist/jwt/man/man1/jwt.1
+++ b/dist/jwt/man/man1/jwt.1
@@ -116,6 +116,11 @@ Suppress warning messages.
 .RS 4
 Show help message and exit.
 .RE
+.sp
+\fB\-V\fP, \fB\-\-version\fP
+.RS 4
+Show version information and exit.
+.RE
 .SH "ARGUMENTS"
 .sp
 \fITOKEN\fP

--- a/dist/theme/man/man1/theme.1
+++ b/dist/theme/man/man1/theme.1
@@ -80,13 +80,13 @@ Providers and handlers are auto\-discovered by function name prefix or loaded
 from configuration files.
 .SH "OPTIONS"
 .sp
-\fB\-\-detect\fP
+\fB\-d\fP, \fB\-\-detect\fP
 .RS 4
 Only detect and print the system appearance (dark or light). Does not run
 the provider or handlers.
 .RE
 .sp
-\fB\-\-list\fP
+\fB\-l\fP, \fB\-\-list\fP
 .RS 4
 List the discovered provider and all registered handlers.
 .RE
@@ -101,7 +101,7 @@ Suppress warning messages.
 Show help message and exit.
 .RE
 .sp
-\fB\-\-version\fP
+\fB\-V\fP, \fB\-\-version\fP
 .RS 4
 Show version information and exit.
 .RE

--- a/scripts/cz/docs/cz.adoc
+++ b/scripts/cz/docs/cz.adoc
@@ -101,7 +101,7 @@ in a terminal, or *lint* mode if receiving input on standard input.
 *-h*, *--help*::
   Display usage information and exit.
 
-*--version*::
+*-V*, *--version*::
   Display version information and exit.
 
 == FILES

--- a/scripts/dotenv/docs/dotenv.adoc
+++ b/scripts/dotenv/docs/dotenv.adoc
@@ -31,7 +31,7 @@ information, see *env*(5).
 
 == OPTIONS
 
-*-e* _FILE_::
+*-e*, *--env-file* _FILE_::
   Specify .env file to load. Can be specified multiple times to load multiple
   files. If not specified, defaults to *.env*. Files are processed in order,
   with later files overriding variables from earlier files.
@@ -49,6 +49,9 @@ information, see *env*(5).
 
 *-h*, *--help*::
   Show help message and exit.
+
+*-V*, *--version*::
+  Show version information and exit.
 
 == ARGUMENTS
 

--- a/scripts/jwt/docs/jwt.adoc
+++ b/scripts/jwt/docs/jwt.adoc
@@ -63,6 +63,9 @@ These options are mutually exclusive. Specifying more than one is an error.
 *-h*, *--help*::
   Show help message and exit.
 
+*-V*, *--version*::
+  Show version information and exit.
+
 == ARGUMENTS
 
 _TOKEN_::

--- a/scripts/theme/docs/theme.adoc
+++ b/scripts/theme/docs/theme.adoc
@@ -35,11 +35,11 @@ from configuration files.
 
 == OPTIONS
 
-*--detect*::
+*-d*, *--detect*::
   Only detect and print the system appearance (dark or light). Does not run
   the provider or handlers.
 
-*--list*::
+*-l*, *--list*::
   List the discovered provider and all registered handlers.
 
 *-q*, *--quiet*::
@@ -48,7 +48,7 @@ from configuration files.
 *-h*, *--help*::
   Show help message and exit.
 
-*--version*::
+*-V*, *--version*::
   Show version information and exit.
 
 == ARGUMENTS


### PR DESCRIPTION
## Summary

Adds missing short option flags to manpage documentation:
- cz: add `-V` to `--version`
- jwt: add `-V --version`
- dotenv: add `-V --version`, `--env-file` to `-e`
- theme: add `-d` to `--detect`, `-l` to `--list`, `-V` to `--version`

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)