### PR TITLE
docs: add version header and git tag revision to manpages

### DIFF
--- a/scripts/cz/docs/cz.adoc
+++ b/scripts/cz/docs/cz.adoc
@@ -1,10 +1,11 @@
 = CZ(1)
 ProventusLabs
+v0.1.0 // x-release-please-version
 :docdate: 2025
 :doctype: manpage
 :manmanual: User Commands
 :mansource: Scriptorium
-:revnumber: 0.1.0 // x-release-please-version
+:manversion: v0.1.0 // x-release-please-version
 :man-linkstyle: pass:[blue R < >]
 
 == NAME

--- a/scripts/dotenv/docs/dotenv.adoc
+++ b/scripts/dotenv/docs/dotenv.adoc
@@ -1,10 +1,11 @@
 = DOTENV(1)
 ProventusLabs
+v0.1.0 // x-release-please-version
 :docdate: 2025
 :doctype: manpage
 :manmanual: User Commands
 :mansource: Scriptorium
-:revnumber: 0.1.0 // x-release-please-version
+:manversion: v0.1.0 // x-release-please-version
 :man-linkstyle: pass:[blue R < >]
 
 == NAME

--- a/scripts/jwt/docs/jwt.adoc
+++ b/scripts/jwt/docs/jwt.adoc
@@ -1,10 +1,11 @@
 = JWT(1)
 ProventusLabs
+v0.1.0 // x-release-please-version
 :docdate: 2025
 :doctype: manpage
 :manmanual: User Commands
 :mansource: Scriptorium
-:revnumber: 0.1.0 // x-release-please-version
+:manversion: v0.1.0 // x-release-please-version
 :man-linkstyle: pass:[blue R < >]
 
 == NAME

--- a/scripts/theme/docs/theme.adoc
+++ b/scripts/theme/docs/theme.adoc
@@ -1,10 +1,11 @@
 = THEME(1)
 ProventusLabs
+v0.1.0 // x-release-please-version
 :docdate: 2025
 :doctype: manpage
 :manmanual: User Commands
 :mansource: Scriptorium
-:revnumber: 0.1.0 // x-release-please-version
+:manversion: v0.1.0 // x-release-please-version
 :man-linkstyle: pass:[blue R < >]
 
 == NAME


### PR DESCRIPTION
## Summary

- Move version to AsciiDoc header line 3 (standard manpage format)
- Remove `:revnumber:` attribute (version now in header)
- Add `== REVISION` section with git tag for nix flake reference

## Test plan

- [ ] Verify manpages build correctly with `make build`
- [ ] Check rendered manpage includes version in header
- [ ] Check REVISION section appears in footer