### PR TITLE
refactor(cz): reduce code duplication with shared helpers

### DIFF
--- a/dist/cz/bin/cz
+++ b/dist/cz/bin/cz
@@ -213,6 +213,9 @@ default_config() {
 # --- begin: scripts/cz/config_parser.sh ---
 # shellcheck shell=bash
 
+# Get scope variable name (handles wildcard -> __wildcard__)
+_scope_var() { [[ "$1" == "*" ]] && echo "CFG_SCOPES___wildcard__" || echo "CFG_SCOPES_$1"; }
+
 # Parse .gitcommitizen configuration from stdin
 # Sets variables: CFG_SETTINGS_*, CFG_SCOPES_*, CFG_TYPES_*
 # Also sets arrays: CFG_SCOPE_NAMES, CFG_TYPE_NAMES
@@ -283,28 +286,16 @@ get_setting() {
 }
 
 # Check if scope exists
-# Usage: scope_exists <name>
 scope_exists() {
-	local name="$1"
 	local var
-	if [[ "$name" == "*" ]]; then
-		var="CFG_SCOPES___wildcard__"
-	else
-		var="CFG_SCOPES_$name"
-	fi
+	var="$(_scope_var "$1")"
 	[[ -n "${!var+x}" ]]
 }
 
 # Get scope patterns
-# Usage: get_scope_patterns <name>
 get_scope_patterns() {
-	local name="$1"
 	local var
-	if [[ "$name" == "*" ]]; then
-		var="CFG_SCOPES___wildcard__"
-	else
-		var="CFG_SCOPES_$name"
-	fi
+	var="$(_scope_var "$1")"
 	echo "${!var:-}"
 }
 
@@ -316,6 +307,13 @@ type_exists() {
 }
 # --- end: scripts/cz/config_parser.sh ---
 # Sets: TYPES, DESCRIPTIONS, SCOPES, GLOBAL_SCOPES, CONFIG_FILE
+
+# Ensure config is loaded (idempotent)
+ensure_config() {
+	[[ -n "${TYPES+x}" && ${#TYPES[@]} -gt 0 ]] && return
+	[[ -z "${CONFIG_FILE:-}" ]] && { find_config || true; }
+	load_config
+}
 
 # Find config file by walking up directory tree
 # Usage: find_config [start_dir]
@@ -562,6 +560,19 @@ hook_status() {
 
 # Path validator module for matching files against scope glob patterns
 
+# --- begin: scripts/cz/helpers.sh ---
+# shellcheck shell=bash
+
+# Shared helper functions for cz
+
+# Trim leading/trailing whitespace from variable
+# Usage: _trim varname
+_trim() {
+	local v="${!1}"
+	v="${v#"${v%%[![:space:]]*}"}"
+	printf -v "$1" '%s' "${v%"${v##*[![:space:]]}"}"
+}
+# --- end: scripts/cz/helpers.sh ---
 # --- skipped (already included): scripts/cz/config_parser.sh ---
 
 # Check if file matches a glob pattern
@@ -613,59 +624,40 @@ file_matches_pattern() {
 # Check if file matches any of a scope's patterns
 # Usage: file_matches_scope <file> <scope>
 file_matches_scope() {
-	local file="$1" scope="$2"
-	local patterns pattern
-
+	local file="$1" scope="$2" patterns pattern
 	patterns="$(get_scope_patterns "$scope")"
 	[[ -z "$patterns" ]] && return 1
 
-	# Split comma-separated patterns and check each
 	IFS=',' read -ra pattern_arr <<<"$patterns"
 	for pattern in "${pattern_arr[@]}"; do
-		# Trim whitespace
-		pattern="${pattern#"${pattern%%[![:space:]]*}"}"
-		pattern="${pattern%"${pattern##*[![:space:]]}"}"
+		_trim pattern
 		file_matches_pattern "$file" "$pattern" && return 0
 	done
-
 	return 1
 }
 
-# Find which scope a file matches
-# Usage: find_matching_scope <file>
-# Outputs scope name if found, empty if none
-# Skips wildcard scope (*)
+# Find which scope a file matches (skips wildcard)
 find_matching_scope() {
 	local file="$1" scope
-
 	for scope in "${CFG_SCOPE_NAMES[@]}"; do
-		# Skip wildcard scope
 		[[ "$scope" == "*" ]] && continue
-		if file_matches_scope "$file" "$scope"; then
+		file_matches_scope "$file" "$scope" && {
 			echo "$scope"
 			return 0
-		fi
+		}
 	done
-
-	echo ""
 	return 1
 }
 
 # Validate all files match a scope
-# Usage: validate_files_against_scope <scope> <file>...
 # Sets VALIDATION_ERRORS array with details on failures
 validate_files_against_scope() {
 	local scope="$1"
 	shift
-	local file
 	VALIDATION_ERRORS=()
-
 	for file in "$@"; do
-		if ! file_matches_scope "$file" "$scope"; then
-			VALIDATION_ERRORS+=("$file does not match scope '$scope'")
-		fi
+		file_matches_scope "$file" "$scope" || VALIDATION_ERRORS+=("$file does not match scope '$scope'")
 	done
-
 	[[ ${#VALIDATION_ERRORS[@]} -eq 0 ]]
 }
 
@@ -677,143 +669,139 @@ validate_files_against_scopes() {
 	local scopes_str="$1"
 	shift
 	local file scope matched
-	local separator
-	separator="$(get_setting multi-scope-separator ",")"
-
+	local IFS
+	IFS="$(get_setting multi-scope-separator ",")"
 	VALIDATION_ERRORS=()
 
-	# Split scopes by separator
-	local IFS="$separator"
 	read -ra scopes_arr <<<"$scopes_str"
-
 	for file in "$@"; do
 		matched=false
 		for scope in "${scopes_arr[@]}"; do
-			# Trim whitespace
-			scope="${scope#"${scope%%[![:space:]]*}"}"
-			scope="${scope%"${scope##*[![:space:]]}"}"
-			if file_matches_scope "$file" "$scope"; then
+			_trim scope
+			file_matches_scope "$file" "$scope" && {
 				matched=true
 				break
-			fi
+			}
 		done
-		if [[ "$matched" == false ]]; then
-			VALIDATION_ERRORS+=("$file does not match any scope in '$scopes_str'")
-		fi
+		[[ "$matched" == false ]] && VALIDATION_ERRORS+=("$file does not match any scope in '$scopes_str'")
 	done
-
 	[[ ${#VALIDATION_ERRORS[@]} -eq 0 ]]
 }
 
 # For strict mode: files must NOT match any scope
-# Usage: validate_strict_no_scope <file>...
 # Sets STRICT_MATCHES array with matches found
 validate_strict_no_scope() {
 	local file scope_match
 	STRICT_MATCHES=()
-
 	for file in "$@"; do
-		scope_match="$(find_matching_scope "$file")"
-		if [[ -n "$scope_match" ]]; then
-			STRICT_MATCHES+=("$file matches scope '$scope_match'")
-		fi
+		scope_match="$(find_matching_scope "$file")" && STRICT_MATCHES+=("$file matches scope '$scope_match'")
 	done
-
 	[[ ${#STRICT_MATCHES[@]} -eq 0 ]]
 }
 # --- end: scripts/cz/path_validator.sh ---
+
+# Output helpers - respect QUIET flag
+_err() { [[ -n "${QUIET:-}" ]] || echo "cz: error: $1" >&2; }
+_hint() { [[ -n "${QUIET:-}" ]] || echo "$1" >&2; }
+_scope_err() {
+	_err "unknown scope '$1'"
+	_hint "Defined scopes: ${CFG_SCOPE_NAMES[*]}"
+}
+_show_errors() {
+	local e
+	for e in "$@"; do _hint "  $e"; done
+}
+
+# Get multi-scope separator
+_get_sep() { get_setting multi-scope-separator ","; }
+
+# Check all scopes in a multi-scope string exist
+# Usage: _check_scopes_exist <scope_str>
+# Sets: _scopes array (trimmed scope names)
+_check_scopes_exist() {
+	local IFS s
+	IFS="$(_get_sep)"
+	read -ra _scopes <<<"$1"
+	for s in "${_scopes[@]}"; do
+		_trim s
+		[[ "$s" == "*" ]] && continue
+		scope_exists "$s" || {
+			_scope_err "$s"
+			return 1
+		}
+	done
+}
 
 cmd_lint() {
 	local message
 	message="$(cat)"
 
-	if [[ -z "$message" ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: empty commit message" >&2
+	[[ -z "$message" ]] && {
+		_err "empty commit message"
 		return 1
-	fi
+	}
 
 	# Load config if not already loaded
-	if [[ -z "${TYPES+x}" || ${#TYPES[@]} -eq 0 ]]; then
-		if [[ -z "${CONFIG_FILE:-}" ]]; then
-			find_config || true
-		fi
-		load_config
-	fi
+	ensure_config
 
 	# Parse first line: type[(scope)][!]: description
 	local first_line="${message%%$'\n'*}"
 	local pattern='^([a-z]+)(\(([a-zA-Z0-9_@/,*-]+)\))?(!)?: (.+)$'
 
 	if [[ ! "$first_line" =~ $pattern ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: invalid commit format" >&2
-		[[ -z "${QUIET:-}" ]] && echo "Expected: <type>[(scope)]: <description>" >&2
+		_err "invalid commit format"
+		_hint "Expected: <type>[(scope)]: <description>"
 		return 1
 	fi
 
-	local type="${BASH_REMATCH[1]}"
-	local scope="${BASH_REMATCH[3]}"
-	local breaking="${BASH_REMATCH[4]}"
-	local description="${BASH_REMATCH[5]}"
+	local type="${BASH_REMATCH[1]}" scope="${BASH_REMATCH[3]}"
+	local breaking="${BASH_REMATCH[4]}" description="${BASH_REMATCH[5]}"
 
 	# Validate type
-	local type_valid=false
 	local type_index=-1
 	for i in "${!TYPES[@]}"; do
-		if [[ "${TYPES[$i]}" == "$type" ]]; then
-			type_valid=true
+		[[ "${TYPES[$i]}" == "$type" ]] && {
 			type_index=$i
 			break
-		fi
+		}
 	done
 
-	if [[ "$type_valid" != true ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown type '$type'" >&2
-		[[ -z "${QUIET:-}" ]] && echo "Allowed types: ${TYPES[*]}" >&2
+	if [[ $type_index -lt 0 ]]; then
+		_err "unknown type '$type'"
+		_hint "Allowed types: ${TYPES[*]}"
 		return 1
 	fi
 
-	# Validate scope if present
-	if [[ -n "$scope" ]]; then
-		local allowed_scopes="${SCOPES[$type_index]}"
-
-		# If scopes are defined for this type, validate against them
-		if [[ -n "$allowed_scopes" ]]; then
-			local scope_valid=false
-			for allowed in $allowed_scopes; do
-				if [[ "$allowed" == "$scope" ]]; then
-					scope_valid=true
-					break
-				fi
-			done
-
-			if [[ "$scope_valid" != true ]]; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: invalid scope '$scope' for type '$type'" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Allowed scopes: $allowed_scopes" >&2
-				return 1
-			fi
-		fi
-	fi
-
-	# Validate description is not empty
-	if [[ -z "$description" || "$description" =~ ^[[:space:]]*$ ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: description cannot be empty" >&2
-		return 1
-	fi
-
-	# Validate breaking change has BREAKING CHANGE footer
-	if [[ -n "$breaking" ]]; then
-		if [[ ! "$message" =~ BREAKING[[:space:]]CHANGE: ]]; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: breaking change (!) requires 'BREAKING CHANGE:' footer" >&2
+	# Validate scope if present and scopes defined for this type
+	if [[ -n "$scope" && -n "${SCOPES[$type_index]}" ]]; then
+		local scope_valid=false allowed
+		for allowed in ${SCOPES[$type_index]}; do
+			[[ "$allowed" == "$scope" ]] && {
+				scope_valid=true
+				break
+			}
+		done
+		if [[ "$scope_valid" != true ]]; then
+			_err "invalid scope '$scope' for type '$type'"
+			_hint "Allowed scopes: ${SCOPES[$type_index]}"
 			return 1
 		fi
 	fi
 
-	# Path validation for INI format with files provided
-	if ! validate_paths_if_needed "$scope"; then
+	# Validate description is not empty
+	[[ -z "$description" || "$description" =~ ^[[:space:]]*$ ]] && {
+		_err "description cannot be empty"
 		return 1
-	fi
+	}
 
-	return 0
+	# Validate breaking change has BREAKING CHANGE footer
+	[[ -n "$breaking" && ! "$message" =~ BREAKING[[:space:]]CHANGE: ]] && {
+		_err "breaking change (!) requires 'BREAKING CHANGE:' footer"
+		return 1
+	}
+
+	# Path validation for INI format with files provided
+	validate_paths_if_needed "$scope"
 }
 
 # Get list of files to validate
@@ -821,154 +809,85 @@ cmd_lint() {
 # Returns file list (one per line) or empty string
 get_files_to_validate() {
 	[[ -z "${FILES:-}" ]] && return
-	# Handle space-separated or newline-separated input
 	echo "$FILES" | tr ' ' '\n' | grep -v '^$'
 }
 
 # Check if scope contains multi-scope separator
-# Usage: is_multi_scope <scope>
-is_multi_scope() {
-	local scope="$1"
-	local separator
-	separator="$(get_setting multi-scope-separator ",")"
-	[[ "$scope" == *"$separator"* ]]
-}
+is_multi_scope() { [[ "$1" == *"$(_get_sep)"* ]]; }
 
 # Validate paths against scope(s) if INI format and files provided
 # Usage: validate_paths_if_needed <scope>
 validate_paths_if_needed() {
-	local scope="$1"
-	local files_str
-	local multi_scope_enabled strict_mode
+	local scope="$1" strict_mode
 
-	# Check strict mode (--no-strict overrides --strict overrides config)
+	# Determine strict mode (--no-strict > --strict > config)
 	if [[ -n "${NO_STRICT:-}" ]]; then
-		strict_mode="false"
+		strict_mode=false
 	elif [[ -n "${STRICT:-}" ]]; then
-		strict_mode="true"
-	else
-		strict_mode="$(get_setting strict "false")"
-	fi
+		strict_mode=true
+	else strict_mode="$(get_setting strict false)"; fi
 
-	# In strict mode with a scope, validate it exists
+	# In strict mode with scope, validate scope exists
 	if [[ "$strict_mode" == "true" && -n "$scope" ]]; then
-		# No scopes defined but scope used - reject
-		if [[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]]; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: scope '$scope' used but no scopes defined in config" >&2
+		[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && {
+			_err "scope '$scope' used but no scopes defined in config"
 			return 1
-		fi
-
-		# Validate scope exists
+		}
 		if is_multi_scope "$scope"; then
-			local separator
-			separator="$(get_setting multi-scope-separator ",")"
-			local IFS="$separator"
-			read -ra scope_arr <<<"$scope"
-			for s in "${scope_arr[@]}"; do
-				s="${s#"${s%%[![:space:]]*}"}"
-				s="${s%"${s##*[![:space:]]}"}"
-				if ! scope_exists "$s" && [[ "$s" != "*" ]]; then
-					[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$s'" >&2
-					[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-					return 1
-				fi
-			done
+			_check_scopes_exist "$scope" || return 1
 		elif [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$scope'" >&2
-			[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
+			_scope_err "$scope"
 			return 1
 		fi
 	fi
 
-	# Skip file validation if no scopes defined
+	# Early exit if no scopes defined or no files to validate
 	[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && return 0
-
-	# Get files to validate
-	files_str="$(get_files_to_validate)"
-	[[ -z "$files_str" ]] && return 0
-
-	# Convert to array
 	local -a files=()
-	while IFS= read -r file; do
-		[[ -n "$file" ]] && files+=("$file")
-	done <<<"$files_str"
-
+	mapfile -t files < <(get_files_to_validate)
 	[[ ${#files[@]} -eq 0 ]] && return 0
 
-	# Check multi-scope setting
-	multi_scope_enabled="$(get_setting multi-scope "false")"
-
-	# If scope provided, validate files against scope(s)
-	if [[ -n "$scope" ]]; then
-		# Check if multi-scope used
-		if is_multi_scope "$scope"; then
-			if [[ "$multi_scope_enabled" != "true" ]]; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: multi-scope not enabled in config" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Set multi-scope = true in [settings] to use multiple scopes" >&2
-				return 1
-			fi
-
-			# Validate each scope exists
-			local separator
-			separator="$(get_setting multi-scope-separator ",")"
-			local IFS="$separator"
-			read -ra scope_arr <<<"$scope"
-			for s in "${scope_arr[@]}"; do
-				s="${s#"${s%%[![:space:]]*}"}"
-				s="${s%"${s##*[![:space:]]}"}"
-				if ! scope_exists "$s" && [[ "$s" != "*" ]]; then
-					[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$s'" >&2
-					[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-					return 1
-				fi
-			done
-
-			# Validate files match any of the scopes
-			if ! validate_files_against_scopes "$scope" "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: files do not match scopes '$scope'" >&2
-				for err in "${VALIDATION_ERRORS[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $err" >&2
-				done
-				return 1
-			fi
-		else
-			# Single scope - validate it exists (unless wildcard)
-			if [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$scope'" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-				return 1
-			fi
-
-			# Wildcard scope matches any files
-			if [[ "$scope" == "*" ]]; then
-				return 0
-			fi
-
-			# Validate files match the scope
-			if ! validate_files_against_scope "$scope" "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: files do not match scope '$scope'" >&2
-				for err in "${VALIDATION_ERRORS[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $err" >&2
-				done
-				return 1
-			fi
+	# No scope provided - strict mode check
+	if [[ -z "$scope" ]]; then
+		[[ "$strict_mode" != "true" ]] && return 0
+		if ! validate_strict_no_scope "${files[@]}"; then
+			_err "strict mode requires scope for scoped files"
+			_show_errors "${STRICT_MATCHES[@]}"
+			_hint "Hint: add a scope that matches these files"
+			return 1
 		fi
-	else
-		# No scope provided - check strict mode
-		if [[ "$strict_mode" == "true" ]]; then
-			# Files must NOT match any defined scope
-			if ! validate_strict_no_scope "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: strict mode requires scope for scoped files" >&2
-				for match in "${STRICT_MATCHES[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $match" >&2
-				done
-				[[ -z "${QUIET:-}" ]] && echo "Hint: add a scope that matches these files" >&2
-				return 1
-			fi
-		fi
+		return 0
 	fi
 
-	return 0
+	# Wildcard scope matches any files
+	[[ "$scope" == "*" ]] && return 0
+
+	# Multi-scope validation
+	if is_multi_scope "$scope"; then
+		[[ "$(get_setting multi-scope false)" != "true" ]] && {
+			_err "multi-scope not enabled in config"
+			_hint "Set multi-scope = true in [settings] to use multiple scopes"
+			return 1
+		}
+		_check_scopes_exist "$scope" || return 1
+		if ! validate_files_against_scopes "$scope" "${files[@]}"; then
+			_err "files do not match scopes '$scope'"
+			_show_errors "${VALIDATION_ERRORS[@]}"
+			return 1
+		fi
+		return 0
+	fi
+
+	# Single scope validation
+	scope_exists "$scope" || {
+		_scope_err "$scope"
+		return 1
+	}
+	if ! validate_files_against_scope "$scope" "${files[@]}"; then
+		_err "files do not match scope '$scope'"
+		_show_errors "${VALIDATION_ERRORS[@]}"
+		return 1
+	fi
 }
 # --- end: scripts/cz/cmd_lint.sh ---
 # --- begin: scripts/cz/cmd_create.sh ---
@@ -978,6 +897,13 @@ validate_paths_if_needed() {
 
 # --- skipped (already included): scripts/cz/config.sh ---
 
+# Gum wrapper - exits 130 on cancel
+_gum() { gum "$@" || exit 130; }
+
+# Prompt for free-form scope input (header varies for test compatibility)
+_scope_input_optional() { _gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"; }
+_scope_input_custom() { _gum input --header "Enter scope:" --placeholder "e.g., api, ui, core"; }
+
 cmd_create() {
 	# Check gum dependency
 	if ! command -v gum &>/dev/null; then
@@ -986,13 +912,7 @@ cmd_create() {
 		exit 1
 	fi
 
-	# Load config if not already loaded
-	if [[ -z "${TYPES+x}" || ${#TYPES[@]} -eq 0 ]]; then
-		if [[ -z "${CONFIG_FILE:-}" ]]; then
-			find_config || true
-		fi
-		load_config
-	fi
+	ensure_config
 
 	# Build type choices: "type - description"
 	local type_choices=()
@@ -1002,122 +922,84 @@ cmd_create() {
 
 	# Select type
 	local type_selection
-	if ! type_selection=$(gum choose --header "Select commit type:" "${type_choices[@]}"); then
-		exit 130
-	fi
+	type_selection=$(_gum choose --header "Select commit type:" "${type_choices[@]}")
 	local type="${type_selection%% - *}"
 
 	# Select or input scope
 	local scope=""
-
 	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
-		# Build scope choices from configured scopes
+		# Build scope choices from configured scopes (skip wildcard)
 		local scope_choices=()
 		for s in "${CFG_SCOPE_NAMES[@]}"; do
-			# Skip wildcard scope
 			[[ "$s" == "*" ]] && continue
 			scope_choices+=("$s")
 		done
 
 		if [[ ${#scope_choices[@]} -gt 0 ]]; then
+			local scope_selection
 			if [[ -n "${STRICT_SCOPES:-}" ]]; then
-				# Strict mode: only configured scopes
 				scope_choices+=("(none)")
-				local scope_selection
-				if ! scope_selection=$(gum choose --header "Select scope:" "${scope_choices[@]}"); then
-					exit 130
-				fi
-				if [[ "$scope_selection" != "(none)" ]]; then
-					scope="$scope_selection"
-				fi
+				scope_selection=$(_gum choose --header "Select scope:" "${scope_choices[@]}")
+				[[ "$scope_selection" != "(none)" ]] && scope="$scope_selection"
 			else
-				# Default: configured scopes + custom option
 				scope_choices+=("(custom)" "(none)")
-				local scope_selection
-				if ! scope_selection=$(gum choose --header "Select scope:" "${scope_choices[@]}"); then
-					exit 130
-				fi
-				if [[ "$scope_selection" == "(custom)" ]]; then
-					if ! scope=$(gum input --header "Enter scope:" --placeholder "e.g., api, ui, core"); then
-						exit 130
-					fi
-				elif [[ "$scope_selection" != "(none)" ]]; then
-					scope="$scope_selection"
-				fi
+				scope_selection=$(_gum choose --header "Select scope:" "${scope_choices[@]}")
+				case "$scope_selection" in
+					"(custom)") scope=$(_scope_input_custom) ;;
+					"(none)") ;;
+					*) scope="$scope_selection" ;;
+				esac
 			fi
 		else
-			# Only wildcard scope defined: free-form input
-			if ! scope=$(gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"); then
-				exit 130
-			fi
+			scope=$(_scope_input_optional)
 		fi
 	else
-		# No configured scopes: free-form input
-		if ! scope=$(gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"); then
-			exit 130
-		fi
+		scope=$(_scope_input_optional)
 	fi
 
 	# Ask about breaking change
 	local breaking=""
-	if gum confirm "Is this a breaking change?"; then
-		breaking="!"
-	fi
+	gum confirm "Is this a breaking change?" && breaking="!"
 
 	# Get description (required)
 	local description=""
 	while [[ -z "$description" ]]; do
-		if ! description=$(gum input --header "Description (required):" --placeholder "Short summary of the change"); then
-			exit 130
-		fi
-		if [[ -z "$description" ]]; then
-			echo "cz: error: description cannot be empty" >&2
-		fi
+		description=$(_gum input --header "Description (required):" --placeholder "Short summary of the change")
+		[[ -z "$description" ]] && echo "cz: error: description cannot be empty" >&2
 	done
 
 	# Get body (optional)
-	local body=""
-	if ! body=$(gum write --header "Body (optional, Ctrl+D to finish):" --placeholder "Detailed explanation of the change..."); then
-		exit 130
-	fi
+	local body
+	body=$(_gum write --header "Body (optional, Ctrl+D to finish):" --placeholder "Detailed explanation of the change...")
 
 	# Get footer
 	local footer=""
 	if [[ -n "$breaking" ]]; then
-		# Breaking change requires explanation
 		local breaking_explanation=""
 		while [[ -z "$breaking_explanation" ]]; do
-			if ! breaking_explanation=$(gum write --header "Breaking change explanation (required):" --placeholder "Describe what breaks and how to migrate..."); then
-				exit 130
-			fi
-			if [[ -z "$breaking_explanation" ]]; then
-				echo "cz: error: breaking change explanation is required" >&2
-			fi
+			breaking_explanation=$(_gum write --header "Breaking change explanation (required):" --placeholder "Describe what breaks and how to migrate...")
+			[[ -z "$breaking_explanation" ]] && echo "cz: error: breaking change explanation is required" >&2
 		done
 		footer="BREAKING CHANGE: $breaking_explanation"
 	else
-		# Optional footer
-		if ! footer=$(gum write --header "Footer (optional, Ctrl+D to finish):" --placeholder "Closes #123, Co-authored-by: ..."); then
-			exit 130
-		fi
+		footer=$(_gum write --header "Footer (optional, Ctrl+D to finish):" --placeholder "Closes #123, Co-authored-by: ...")
 	fi
 
 	# Format output
 	local header="$type"
-	if [[ -n "$scope" ]]; then
-		header="${header}(${scope})"
-	fi
+	[[ -n "$scope" ]] && header="${header}(${scope})"
 	header="${header}${breaking}: ${description}"
 
 	echo "$header"
-	if [[ -n "$body" ]]; then
+	[[ -n "$body" ]] && {
 		echo
 		echo "$body"
-	fi
-	if [[ -n "$footer" ]]; then
+	}
+	[[ -n "$footer" ]] && {
 		echo
 		echo "$footer"
-	fi
+	}
+	return 0
 }
 # --- end: scripts/cz/cmd_create.sh ---
 

--- a/scripts/cz/cmd_create.sh
+++ b/scripts/cz/cmd_create.sh
@@ -5,6 +5,13 @@
 # @bundle source
 . ./config.sh
 
+# Gum wrapper - exits 130 on cancel
+_gum() { gum "$@" || exit 130; }
+
+# Prompt for free-form scope input (header varies for test compatibility)
+_scope_input_optional() { _gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"; }
+_scope_input_custom() { _gum input --header "Enter scope:" --placeholder "e.g., api, ui, core"; }
+
 cmd_create() {
 	# Check gum dependency
 	if ! command -v gum &>/dev/null; then
@@ -13,13 +20,7 @@ cmd_create() {
 		exit 1
 	fi
 
-	# Load config if not already loaded
-	if [[ -z "${TYPES+x}" || ${#TYPES[@]} -eq 0 ]]; then
-		if [[ -z "${CONFIG_FILE:-}" ]]; then
-			find_config || true
-		fi
-		load_config
-	fi
+	ensure_config
 
 	# Build type choices: "type - description"
 	local type_choices=()
@@ -29,120 +30,82 @@ cmd_create() {
 
 	# Select type
 	local type_selection
-	if ! type_selection=$(gum choose --header "Select commit type:" "${type_choices[@]}"); then
-		exit 130
-	fi
+	type_selection=$(_gum choose --header "Select commit type:" "${type_choices[@]}")
 	local type="${type_selection%% - *}"
 
 	# Select or input scope
 	local scope=""
-
 	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
-		# Build scope choices from configured scopes
+		# Build scope choices from configured scopes (skip wildcard)
 		local scope_choices=()
 		for s in "${CFG_SCOPE_NAMES[@]}"; do
-			# Skip wildcard scope
 			[[ "$s" == "*" ]] && continue
 			scope_choices+=("$s")
 		done
 
 		if [[ ${#scope_choices[@]} -gt 0 ]]; then
+			local scope_selection
 			if [[ -n "${STRICT_SCOPES:-}" ]]; then
-				# Strict mode: only configured scopes
 				scope_choices+=("(none)")
-				local scope_selection
-				if ! scope_selection=$(gum choose --header "Select scope:" "${scope_choices[@]}"); then
-					exit 130
-				fi
-				if [[ "$scope_selection" != "(none)" ]]; then
-					scope="$scope_selection"
-				fi
+				scope_selection=$(_gum choose --header "Select scope:" "${scope_choices[@]}")
+				[[ "$scope_selection" != "(none)" ]] && scope="$scope_selection"
 			else
-				# Default: configured scopes + custom option
 				scope_choices+=("(custom)" "(none)")
-				local scope_selection
-				if ! scope_selection=$(gum choose --header "Select scope:" "${scope_choices[@]}"); then
-					exit 130
-				fi
-				if [[ "$scope_selection" == "(custom)" ]]; then
-					if ! scope=$(gum input --header "Enter scope:" --placeholder "e.g., api, ui, core"); then
-						exit 130
-					fi
-				elif [[ "$scope_selection" != "(none)" ]]; then
-					scope="$scope_selection"
-				fi
+				scope_selection=$(_gum choose --header "Select scope:" "${scope_choices[@]}")
+				case "$scope_selection" in
+					"(custom)") scope=$(_scope_input_custom) ;;
+					"(none)") ;;
+					*) scope="$scope_selection" ;;
+				esac
 			fi
 		else
-			# Only wildcard scope defined: free-form input
-			if ! scope=$(gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"); then
-				exit 130
-			fi
+			scope=$(_scope_input_optional)
 		fi
 	else
-		# No configured scopes: free-form input
-		if ! scope=$(gum input --header "Scope (optional):" --placeholder "e.g., api, ui, core"); then
-			exit 130
-		fi
+		scope=$(_scope_input_optional)
 	fi
 
 	# Ask about breaking change
 	local breaking=""
-	if gum confirm "Is this a breaking change?"; then
-		breaking="!"
-	fi
+	gum confirm "Is this a breaking change?" && breaking="!"
 
 	# Get description (required)
 	local description=""
 	while [[ -z "$description" ]]; do
-		if ! description=$(gum input --header "Description (required):" --placeholder "Short summary of the change"); then
-			exit 130
-		fi
-		if [[ -z "$description" ]]; then
-			echo "cz: error: description cannot be empty" >&2
-		fi
+		description=$(_gum input --header "Description (required):" --placeholder "Short summary of the change")
+		[[ -z "$description" ]] && echo "cz: error: description cannot be empty" >&2
 	done
 
 	# Get body (optional)
-	local body=""
-	if ! body=$(gum write --header "Body (optional, Ctrl+D to finish):" --placeholder "Detailed explanation of the change..."); then
-		exit 130
-	fi
+	local body
+	body=$(_gum write --header "Body (optional, Ctrl+D to finish):" --placeholder "Detailed explanation of the change...")
 
 	# Get footer
 	local footer=""
 	if [[ -n "$breaking" ]]; then
-		# Breaking change requires explanation
 		local breaking_explanation=""
 		while [[ -z "$breaking_explanation" ]]; do
-			if ! breaking_explanation=$(gum write --header "Breaking change explanation (required):" --placeholder "Describe what breaks and how to migrate..."); then
-				exit 130
-			fi
-			if [[ -z "$breaking_explanation" ]]; then
-				echo "cz: error: breaking change explanation is required" >&2
-			fi
+			breaking_explanation=$(_gum write --header "Breaking change explanation (required):" --placeholder "Describe what breaks and how to migrate...")
+			[[ -z "$breaking_explanation" ]] && echo "cz: error: breaking change explanation is required" >&2
 		done
 		footer="BREAKING CHANGE: $breaking_explanation"
 	else
-		# Optional footer
-		if ! footer=$(gum write --header "Footer (optional, Ctrl+D to finish):" --placeholder "Closes #123, Co-authored-by: ..."); then
-			exit 130
-		fi
+		footer=$(_gum write --header "Footer (optional, Ctrl+D to finish):" --placeholder "Closes #123, Co-authored-by: ...")
 	fi
 
 	# Format output
 	local header="$type"
-	if [[ -n "$scope" ]]; then
-		header="${header}(${scope})"
-	fi
+	[[ -n "$scope" ]] && header="${header}(${scope})"
 	header="${header}${breaking}: ${description}"
 
 	echo "$header"
-	if [[ -n "$body" ]]; then
+	[[ -n "$body" ]] && {
 		echo
 		echo "$body"
-	fi
-	if [[ -n "$footer" ]]; then
+	}
+	[[ -n "$footer" ]] && {
 		echo
 		echo "$footer"
-	fi
+	}
+	return 0
 }

--- a/scripts/cz/cmd_lint.sh
+++ b/scripts/cz/cmd_lint.sh
@@ -7,97 +7,108 @@
 # @bundle source
 . ./path_validator.sh
 
+# Output helpers - respect QUIET flag
+_err() { [[ -n "${QUIET:-}" ]] || echo "cz: error: $1" >&2; }
+_hint() { [[ -n "${QUIET:-}" ]] || echo "$1" >&2; }
+_scope_err() {
+	_err "unknown scope '$1'"
+	_hint "Defined scopes: ${CFG_SCOPE_NAMES[*]}"
+}
+_show_errors() {
+	local e
+	for e in "$@"; do _hint "  $e"; done
+}
+
+# Get multi-scope separator
+_get_sep() { get_setting multi-scope-separator ","; }
+
+# Check all scopes in a multi-scope string exist
+# Usage: _check_scopes_exist <scope_str>
+# Sets: _scopes array (trimmed scope names)
+_check_scopes_exist() {
+	local IFS s
+	IFS="$(_get_sep)"
+	read -ra _scopes <<<"$1"
+	for s in "${_scopes[@]}"; do
+		_trim s
+		[[ "$s" == "*" ]] && continue
+		scope_exists "$s" || {
+			_scope_err "$s"
+			return 1
+		}
+	done
+}
+
 cmd_lint() {
 	local message
 	message="$(cat)"
 
-	if [[ -z "$message" ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: empty commit message" >&2
+	[[ -z "$message" ]] && {
+		_err "empty commit message"
 		return 1
-	fi
+	}
 
 	# Load config if not already loaded
-	if [[ -z "${TYPES+x}" || ${#TYPES[@]} -eq 0 ]]; then
-		if [[ -z "${CONFIG_FILE:-}" ]]; then
-			find_config || true
-		fi
-		load_config
-	fi
+	ensure_config
 
 	# Parse first line: type[(scope)][!]: description
 	local first_line="${message%%$'\n'*}"
 	local pattern='^([a-z]+)(\(([a-zA-Z0-9_@/,*-]+)\))?(!)?: (.+)$'
 
 	if [[ ! "$first_line" =~ $pattern ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: invalid commit format" >&2
-		[[ -z "${QUIET:-}" ]] && echo "Expected: <type>[(scope)]: <description>" >&2
+		_err "invalid commit format"
+		_hint "Expected: <type>[(scope)]: <description>"
 		return 1
 	fi
 
-	local type="${BASH_REMATCH[1]}"
-	local scope="${BASH_REMATCH[3]}"
-	local breaking="${BASH_REMATCH[4]}"
-	local description="${BASH_REMATCH[5]}"
+	local type="${BASH_REMATCH[1]}" scope="${BASH_REMATCH[3]}"
+	local breaking="${BASH_REMATCH[4]}" description="${BASH_REMATCH[5]}"
 
 	# Validate type
-	local type_valid=false
 	local type_index=-1
 	for i in "${!TYPES[@]}"; do
-		if [[ "${TYPES[$i]}" == "$type" ]]; then
-			type_valid=true
+		[[ "${TYPES[$i]}" == "$type" ]] && {
 			type_index=$i
 			break
-		fi
+		}
 	done
 
-	if [[ "$type_valid" != true ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown type '$type'" >&2
-		[[ -z "${QUIET:-}" ]] && echo "Allowed types: ${TYPES[*]}" >&2
+	if [[ $type_index -lt 0 ]]; then
+		_err "unknown type '$type'"
+		_hint "Allowed types: ${TYPES[*]}"
 		return 1
 	fi
 
-	# Validate scope if present
-	if [[ -n "$scope" ]]; then
-		local allowed_scopes="${SCOPES[$type_index]}"
-
-		# If scopes are defined for this type, validate against them
-		if [[ -n "$allowed_scopes" ]]; then
-			local scope_valid=false
-			for allowed in $allowed_scopes; do
-				if [[ "$allowed" == "$scope" ]]; then
-					scope_valid=true
-					break
-				fi
-			done
-
-			if [[ "$scope_valid" != true ]]; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: invalid scope '$scope' for type '$type'" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Allowed scopes: $allowed_scopes" >&2
-				return 1
-			fi
-		fi
-	fi
-
-	# Validate description is not empty
-	if [[ -z "$description" || "$description" =~ ^[[:space:]]*$ ]]; then
-		[[ -z "${QUIET:-}" ]] && echo "cz: error: description cannot be empty" >&2
-		return 1
-	fi
-
-	# Validate breaking change has BREAKING CHANGE footer
-	if [[ -n "$breaking" ]]; then
-		if [[ ! "$message" =~ BREAKING[[:space:]]CHANGE: ]]; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: breaking change (!) requires 'BREAKING CHANGE:' footer" >&2
+	# Validate scope if present and scopes defined for this type
+	if [[ -n "$scope" && -n "${SCOPES[$type_index]}" ]]; then
+		local scope_valid=false allowed
+		for allowed in ${SCOPES[$type_index]}; do
+			[[ "$allowed" == "$scope" ]] && {
+				scope_valid=true
+				break
+			}
+		done
+		if [[ "$scope_valid" != true ]]; then
+			_err "invalid scope '$scope' for type '$type'"
+			_hint "Allowed scopes: ${SCOPES[$type_index]}"
 			return 1
 		fi
 	fi
 
-	# Path validation for INI format with files provided
-	if ! validate_paths_if_needed "$scope"; then
+	# Validate description is not empty
+	[[ -z "$description" || "$description" =~ ^[[:space:]]*$ ]] && {
+		_err "description cannot be empty"
 		return 1
-	fi
+	}
 
-	return 0
+	# Validate breaking change has BREAKING CHANGE footer
+	[[ -n "$breaking" && ! "$message" =~ BREAKING[[:space:]]CHANGE: ]] && {
+		_err "breaking change (!) requires 'BREAKING CHANGE:' footer"
+		return 1
+	}
+
+	# Path validation for INI format with files provided
+	validate_paths_if_needed "$scope"
 }
 
 # Get list of files to validate
@@ -105,152 +116,83 @@ cmd_lint() {
 # Returns file list (one per line) or empty string
 get_files_to_validate() {
 	[[ -z "${FILES:-}" ]] && return
-	# Handle space-separated or newline-separated input
 	echo "$FILES" | tr ' ' '\n' | grep -v '^$'
 }
 
 # Check if scope contains multi-scope separator
-# Usage: is_multi_scope <scope>
-is_multi_scope() {
-	local scope="$1"
-	local separator
-	separator="$(get_setting multi-scope-separator ",")"
-	[[ "$scope" == *"$separator"* ]]
-}
+is_multi_scope() { [[ "$1" == *"$(_get_sep)"* ]]; }
 
 # Validate paths against scope(s) if INI format and files provided
 # Usage: validate_paths_if_needed <scope>
 validate_paths_if_needed() {
-	local scope="$1"
-	local files_str
-	local multi_scope_enabled strict_mode
+	local scope="$1" strict_mode
 
-	# Check strict mode (--no-strict overrides --strict overrides config)
+	# Determine strict mode (--no-strict > --strict > config)
 	if [[ -n "${NO_STRICT:-}" ]]; then
-		strict_mode="false"
+		strict_mode=false
 	elif [[ -n "${STRICT:-}" ]]; then
-		strict_mode="true"
-	else
-		strict_mode="$(get_setting strict "false")"
-	fi
+		strict_mode=true
+	else strict_mode="$(get_setting strict false)"; fi
 
-	# In strict mode with a scope, validate it exists
+	# In strict mode with scope, validate scope exists
 	if [[ "$strict_mode" == "true" && -n "$scope" ]]; then
-		# No scopes defined but scope used - reject
-		if [[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]]; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: scope '$scope' used but no scopes defined in config" >&2
+		[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && {
+			_err "scope '$scope' used but no scopes defined in config"
 			return 1
-		fi
-
-		# Validate scope exists
+		}
 		if is_multi_scope "$scope"; then
-			local separator
-			separator="$(get_setting multi-scope-separator ",")"
-			local IFS="$separator"
-			read -ra scope_arr <<<"$scope"
-			for s in "${scope_arr[@]}"; do
-				s="${s#"${s%%[![:space:]]*}"}"
-				s="${s%"${s##*[![:space:]]}"}"
-				if ! scope_exists "$s" && [[ "$s" != "*" ]]; then
-					[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$s'" >&2
-					[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-					return 1
-				fi
-			done
+			_check_scopes_exist "$scope" || return 1
 		elif [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
-			[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$scope'" >&2
-			[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
+			_scope_err "$scope"
 			return 1
 		fi
 	fi
 
-	# Skip file validation if no scopes defined
+	# Early exit if no scopes defined or no files to validate
 	[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && return 0
-
-	# Get files to validate
-	files_str="$(get_files_to_validate)"
-	[[ -z "$files_str" ]] && return 0
-
-	# Convert to array
 	local -a files=()
-	while IFS= read -r file; do
-		[[ -n "$file" ]] && files+=("$file")
-	done <<<"$files_str"
-
+	mapfile -t files < <(get_files_to_validate)
 	[[ ${#files[@]} -eq 0 ]] && return 0
 
-	# Check multi-scope setting
-	multi_scope_enabled="$(get_setting multi-scope "false")"
-
-	# If scope provided, validate files against scope(s)
-	if [[ -n "$scope" ]]; then
-		# Check if multi-scope used
-		if is_multi_scope "$scope"; then
-			if [[ "$multi_scope_enabled" != "true" ]]; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: multi-scope not enabled in config" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Set multi-scope = true in [settings] to use multiple scopes" >&2
-				return 1
-			fi
-
-			# Validate each scope exists
-			local separator
-			separator="$(get_setting multi-scope-separator ",")"
-			local IFS="$separator"
-			read -ra scope_arr <<<"$scope"
-			for s in "${scope_arr[@]}"; do
-				s="${s#"${s%%[![:space:]]*}"}"
-				s="${s%"${s##*[![:space:]]}"}"
-				if ! scope_exists "$s" && [[ "$s" != "*" ]]; then
-					[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$s'" >&2
-					[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-					return 1
-				fi
-			done
-
-			# Validate files match any of the scopes
-			if ! validate_files_against_scopes "$scope" "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: files do not match scopes '$scope'" >&2
-				for err in "${VALIDATION_ERRORS[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $err" >&2
-				done
-				return 1
-			fi
-		else
-			# Single scope - validate it exists (unless wildcard)
-			if [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: unknown scope '$scope'" >&2
-				[[ -z "${QUIET:-}" ]] && echo "Defined scopes: ${CFG_SCOPE_NAMES[*]}" >&2
-				return 1
-			fi
-
-			# Wildcard scope matches any files
-			if [[ "$scope" == "*" ]]; then
-				return 0
-			fi
-
-			# Validate files match the scope
-			if ! validate_files_against_scope "$scope" "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: files do not match scope '$scope'" >&2
-				for err in "${VALIDATION_ERRORS[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $err" >&2
-				done
-				return 1
-			fi
+	# No scope provided - strict mode check
+	if [[ -z "$scope" ]]; then
+		[[ "$strict_mode" != "true" ]] && return 0
+		if ! validate_strict_no_scope "${files[@]}"; then
+			_err "strict mode requires scope for scoped files"
+			_show_errors "${STRICT_MATCHES[@]}"
+			_hint "Hint: add a scope that matches these files"
+			return 1
 		fi
-	else
-		# No scope provided - check strict mode
-		if [[ "$strict_mode" == "true" ]]; then
-			# Files must NOT match any defined scope
-			if ! validate_strict_no_scope "${files[@]}"; then
-				[[ -z "${QUIET:-}" ]] && echo "cz: error: strict mode requires scope for scoped files" >&2
-				for match in "${STRICT_MATCHES[@]}"; do
-					[[ -z "${QUIET:-}" ]] && echo "  $match" >&2
-				done
-				[[ -z "${QUIET:-}" ]] && echo "Hint: add a scope that matches these files" >&2
-				return 1
-			fi
-		fi
+		return 0
 	fi
 
-	return 0
+	# Wildcard scope matches any files
+	[[ "$scope" == "*" ]] && return 0
+
+	# Multi-scope validation
+	if is_multi_scope "$scope"; then
+		[[ "$(get_setting multi-scope false)" != "true" ]] && {
+			_err "multi-scope not enabled in config"
+			_hint "Set multi-scope = true in [settings] to use multiple scopes"
+			return 1
+		}
+		_check_scopes_exist "$scope" || return 1
+		if ! validate_files_against_scopes "$scope" "${files[@]}"; then
+			_err "files do not match scopes '$scope'"
+			_show_errors "${VALIDATION_ERRORS[@]}"
+			return 1
+		fi
+		return 0
+	fi
+
+	# Single scope validation
+	scope_exists "$scope" || {
+		_scope_err "$scope"
+		return 1
+	}
+	if ! validate_files_against_scope "$scope" "${files[@]}"; then
+		_err "files do not match scope '$scope'"
+		_show_errors "${VALIDATION_ERRORS[@]}"
+		return 1
+	fi
 }

--- a/scripts/cz/config.sh
+++ b/scripts/cz/config.sh
@@ -8,6 +8,13 @@
 . ./config_parser.sh
 # Sets: TYPES, DESCRIPTIONS, SCOPES, GLOBAL_SCOPES, CONFIG_FILE
 
+# Ensure config is loaded (idempotent)
+ensure_config() {
+	[[ -n "${TYPES+x}" && ${#TYPES[@]} -gt 0 ]] && return
+	[[ -z "${CONFIG_FILE:-}" ]] && { find_config || true; }
+	load_config
+}
+
 # Find config file by walking up directory tree
 # Usage: find_config [start_dir]
 # Returns: 0 if found (path in CONFIG_FILE), 1 if not found

--- a/scripts/cz/config_parser.sh
+++ b/scripts/cz/config_parser.sh
@@ -1,5 +1,8 @@
 # shellcheck shell=bash
 
+# Get scope variable name (handles wildcard -> __wildcard__)
+_scope_var() { [[ "$1" == "*" ]] && echo "CFG_SCOPES___wildcard__" || echo "CFG_SCOPES_$1"; }
+
 # Parse .gitcommitizen configuration from stdin
 # Sets variables: CFG_SETTINGS_*, CFG_SCOPES_*, CFG_TYPES_*
 # Also sets arrays: CFG_SCOPE_NAMES, CFG_TYPE_NAMES
@@ -70,28 +73,16 @@ get_setting() {
 }
 
 # Check if scope exists
-# Usage: scope_exists <name>
 scope_exists() {
-	local name="$1"
 	local var
-	if [[ "$name" == "*" ]]; then
-		var="CFG_SCOPES___wildcard__"
-	else
-		var="CFG_SCOPES_$name"
-	fi
+	var="$(_scope_var "$1")"
 	[[ -n "${!var+x}" ]]
 }
 
 # Get scope patterns
-# Usage: get_scope_patterns <name>
 get_scope_patterns() {
-	local name="$1"
 	local var
-	if [[ "$name" == "*" ]]; then
-		var="CFG_SCOPES___wildcard__"
-	else
-		var="CFG_SCOPES_$name"
-	fi
+	var="$(_scope_var "$1")"
 	echo "${!var:-}"
 }
 

--- a/scripts/cz/helpers.sh
+++ b/scripts/cz/helpers.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+# Shared helper functions for cz
+
+# Trim leading/trailing whitespace from variable
+# Usage: _trim varname
+_trim() {
+	local v="${!1}"
+	v="${v#"${v%%[![:space:]]*}"}"
+	printf -v "$1" '%s' "${v%"${v##*[![:space:]]}"}"
+}

--- a/scripts/cz/path_validator.sh
+++ b/scripts/cz/path_validator.sh
@@ -3,6 +3,8 @@
 # Path validator module for matching files against scope glob patterns
 
 # @bundle source
+. ./helpers.sh
+# @bundle source
 . ./config_parser.sh
 
 # Check if file matches a glob pattern
@@ -54,59 +56,40 @@ file_matches_pattern() {
 # Check if file matches any of a scope's patterns
 # Usage: file_matches_scope <file> <scope>
 file_matches_scope() {
-	local file="$1" scope="$2"
-	local patterns pattern
-
+	local file="$1" scope="$2" patterns pattern
 	patterns="$(get_scope_patterns "$scope")"
 	[[ -z "$patterns" ]] && return 1
 
-	# Split comma-separated patterns and check each
 	IFS=',' read -ra pattern_arr <<<"$patterns"
 	for pattern in "${pattern_arr[@]}"; do
-		# Trim whitespace
-		pattern="${pattern#"${pattern%%[![:space:]]*}"}"
-		pattern="${pattern%"${pattern##*[![:space:]]}"}"
+		_trim pattern
 		file_matches_pattern "$file" "$pattern" && return 0
 	done
-
 	return 1
 }
 
-# Find which scope a file matches
-# Usage: find_matching_scope <file>
-# Outputs scope name if found, empty if none
-# Skips wildcard scope (*)
+# Find which scope a file matches (skips wildcard)
 find_matching_scope() {
 	local file="$1" scope
-
 	for scope in "${CFG_SCOPE_NAMES[@]}"; do
-		# Skip wildcard scope
 		[[ "$scope" == "*" ]] && continue
-		if file_matches_scope "$file" "$scope"; then
+		file_matches_scope "$file" "$scope" && {
 			echo "$scope"
 			return 0
-		fi
+		}
 	done
-
-	echo ""
 	return 1
 }
 
 # Validate all files match a scope
-# Usage: validate_files_against_scope <scope> <file>...
 # Sets VALIDATION_ERRORS array with details on failures
 validate_files_against_scope() {
 	local scope="$1"
 	shift
-	local file
 	VALIDATION_ERRORS=()
-
 	for file in "$@"; do
-		if ! file_matches_scope "$file" "$scope"; then
-			VALIDATION_ERRORS+=("$file does not match scope '$scope'")
-		fi
+		file_matches_scope "$file" "$scope" || VALIDATION_ERRORS+=("$file does not match scope '$scope'")
 	done
-
 	[[ ${#VALIDATION_ERRORS[@]} -eq 0 ]]
 }
 
@@ -118,47 +101,32 @@ validate_files_against_scopes() {
 	local scopes_str="$1"
 	shift
 	local file scope matched
-	local separator
-	separator="$(get_setting multi-scope-separator ",")"
-
+	local IFS
+	IFS="$(get_setting multi-scope-separator ",")"
 	VALIDATION_ERRORS=()
 
-	# Split scopes by separator
-	local IFS="$separator"
 	read -ra scopes_arr <<<"$scopes_str"
-
 	for file in "$@"; do
 		matched=false
 		for scope in "${scopes_arr[@]}"; do
-			# Trim whitespace
-			scope="${scope#"${scope%%[![:space:]]*}"}"
-			scope="${scope%"${scope##*[![:space:]]}"}"
-			if file_matches_scope "$file" "$scope"; then
+			_trim scope
+			file_matches_scope "$file" "$scope" && {
 				matched=true
 				break
-			fi
+			}
 		done
-		if [[ "$matched" == false ]]; then
-			VALIDATION_ERRORS+=("$file does not match any scope in '$scopes_str'")
-		fi
+		[[ "$matched" == false ]] && VALIDATION_ERRORS+=("$file does not match any scope in '$scopes_str'")
 	done
-
 	[[ ${#VALIDATION_ERRORS[@]} -eq 0 ]]
 }
 
 # For strict mode: files must NOT match any scope
-# Usage: validate_strict_no_scope <file>...
 # Sets STRICT_MATCHES array with matches found
 validate_strict_no_scope() {
 	local file scope_match
 	STRICT_MATCHES=()
-
 	for file in "$@"; do
-		scope_match="$(find_matching_scope "$file")"
-		if [[ -n "$scope_match" ]]; then
-			STRICT_MATCHES+=("$file matches scope '$scope_match'")
-		fi
+		scope_match="$(find_matching_scope "$file")" && STRICT_MATCHES+=("$file matches scope '$scope_match'")
 	done
-
 	[[ ${#STRICT_MATCHES[@]} -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Refactor cz script to reduce code duplication by extracting common patterns into reusable helpers.

**Changes:**
- Add `helpers.sh` with shared `_trim()` function used by path_validator and cmd_lint
- Add `ensure_config()` to consolidate repeated config loading boilerplate
- Add `_scope_var()` to handle wildcard scope variable names
- Add output helpers (`_err`, `_hint`, `_show_errors`) for quiet-aware error messages
- Add `_gum` wrapper and scope input helpers in cmd_create
- Flatten `validate_paths_if_needed` control flow with early returns
- Deduplicate multi-scope validation logic with `_check_scopes_exist`

**Results:**
| File | Before | After | Change |
|------|--------|-------|--------|
| cmd_lint.sh | 256 | 198 | -23% |
| path_validator.sh | 164 | 132 | -20% |
| cmd_create.sh | 148 | 111 | -25% |
| config_parser.sh | 103 | 94 | -9% |
| config.sh | 63 | 70 | +7 (helper) |
| helpers.sh | - | 11 | new |

**Net reduction: ~118 lines** (307 deletions, 189 insertions)

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)