### PR TITLE
feat(bundle): add CLI options with getoptions

### DIFF
--- a/utils/bundle.sh
+++ b/utils/bundle.sh
@@ -1,17 +1,41 @@
 #!/usr/bin/env bash
 # bundle.sh — recursively inline sourced scripts into a single file
-# Usage: bundle.sh <entry-file>
-#
-# Features:
-#   - Use `# @bundle source` before a `source`/`.` to inline that file
-#   - Use `# @bundle cmd <command>` to inline command output
-#   - Use `# @bundle keep` to mark blocks to preserve when referenced by @bundle cmd -f
-#   - Use `# @bundle end` to mark end of block
-#   - Tracks included files to avoid duplicates
-#   - Preserves shebang from entry file, errors on mismatched shebangs
-#   - Source statements without `# @bundle source` are kept verbatim
 
 set -euo pipefail
+
+# shellcheck disable=SC2034 # VERSION used by getoptions disp
+VERSION=0.1.0
+
+parser_definition() {
+	# shellcheck disable=SC2016 # Single quotes intentional for literal backticks in help text
+	setup REST help:usage abbr:true -- \
+		"Usage: bundle.sh [options] <entry-file>" \
+		'' \
+		'Recursively inline sourced scripts into a single file.' \
+		'' \
+		'Features:' \
+		'  - Use `# @bundle source` before a `source`/`.` to inline that file' \
+		'  - Use `# @bundle cmd <command>` to inline command output' \
+		'  - Use `# @bundle keep` to mark blocks to preserve when referenced by @bundle cmd -f' \
+		'  - Use `# @bundle end` to mark end of block' \
+		'  - Tracks included files to avoid duplicates' \
+		'  - Preserves shebang from entry file, errors on mismatched shebangs' \
+		'  - Source statements without `# @bundle source` are kept verbatim' \
+		''
+	msg -- 'Options:'
+	flag STRIP_COMMENTS -s --strip-comments -- "Strip comments from source files"
+	flag HIDE_MARKERS -n --hide-markers -- "Suppress bundle marker comments"
+	disp :usage -h --help
+	disp VERSION -V --version
+}
+
+eval "$(getoptions parser_definition parse)"
+parse "$@"
+eval "set -- $REST"
+
+STRIP_COMMENTS="${STRIP_COMMENTS:-0}"
+HIDE_MARKERS="${HIDE_MARKERS:-0}"
+
 declare -A seen
 is_entry=1
 entry_shebang=""
@@ -98,6 +122,11 @@ bundle_file() {
 			continue
 		fi
 
+		# Strip full-line comments if requested (but not @bundle directives)
+		if [[ "$STRIP_COMMENTS" -eq 1 && "$stripped" == '#'* && "$stripped" != '# @bundle'* ]]; then
+			continue
+		fi
+
 		case "$stripped" in
 			'# @bundle source')
 				bundle_next=1
@@ -123,7 +152,7 @@ bundle_file() {
 						local keep_content
 						keep_content="$(extract_keep_blocks "$ref_path")"
 						if [[ -n "$keep_content" ]]; then
-							emit "$cmd_indent" "# --- keep from: ${ref_path#"$PWD/"} ---"
+							[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$cmd_indent" "# --- keep from: ${ref_path#"$PWD/"} ---" || true
 							while IFS= read -r keep_line; do
 								emit "$cmd_indent" "$keep_line"
 							done <<<"$keep_content"
@@ -133,11 +162,11 @@ bundle_file() {
 
 				# Run the command and indent each line of output
 				# Convert << to <<- so heredocs work when indented (<<- strips leading tabs)
-				emit "$cmd_indent" "# --- begin: $cmd ---"
+				[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$cmd_indent" "# --- begin: $cmd ---" || true
 				while IFS= read -r cmd_line; do
 					emit "$cmd_indent" "$cmd_line"
 				done < <(cd "$dir" && eval "$cmd" | sed 's/<<\([^-]\)/<<-\1/g')
-				emit "$cmd_indent" "# --- end: $cmd ---"
+				[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$cmd_indent" "# --- end: $cmd ---" || true
 				skip_until_end=1
 				;;
 			*)
@@ -172,11 +201,11 @@ bundle_file() {
 					if [[ -f "$dep_path" ]]; then
 						if [[ -z "${seen[$dep_path]:-}" ]]; then
 							seen["$dep_path"]=1
-							emit "$src_indent" "# --- begin: ${dep_path#"$PWD/"} ---"
+							[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$src_indent" "# --- begin: ${dep_path#"$PWD/"} ---" || true
 							bundle_file "$dep_path" "$src_indent"
-							emit "$src_indent" "# --- end: ${dep_path#"$PWD/"} ---"
+							[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$src_indent" "# --- end: ${dep_path#"$PWD/"} ---" || true
 						else
-							emit "$src_indent" "# --- skipped (already included): ${dep_path#"$PWD/"} ---"
+							[[ "$HIDE_MARKERS" -eq 0 ]] && emit "$src_indent" "# --- skipped (already included): ${dep_path#"$PWD/"} ---" || true
 						fi
 					else
 						echo "Error: file not found: $dep_path" >&2

--- a/utils/bundle_spec.sh
+++ b/utils/bundle_spec.sh
@@ -12,6 +12,34 @@ Describe 'bundle.sh'
 	BeforeEach 'setup'
 	AfterEach 'cleanup'
 
+	Describe 'CLI options'
+		It 'shows help with -h'
+			When run script ./bundle.sh -h
+			The status should be success
+			The output should include 'Usage:'
+			The output should include '--strip-comments'
+			The output should include '--hide-markers'
+		End
+
+		It 'shows help with --help'
+			When run script ./bundle.sh --help
+			The status should be success
+			The output should include 'Usage:'
+		End
+
+		It 'shows version with -V'
+			When run script ./bundle.sh -V
+			The status should be success
+			The output should match pattern '*.*.*'
+		End
+
+		It 'shows version with --version'
+			When run script ./bundle.sh --version
+			The status should be success
+			The output should match pattern '*.*.*'
+		End
+	End
+
 	Describe 'basic functionality'
 		It 'preserves shebang from entry file'
 			echo '#!/usr/bin/env bash' > "$TEST_DIR/entry.sh"
@@ -602,6 +630,199 @@ EOF
 			# Begin marker should start at column 0 (no leading whitespace)
 			The line 2 of output should start with '# --- begin:'
 			The line 3 of output should equal 'TOP_VAR=yes'
+		End
+	End
+
+	Describe '--strip-comments option'
+		It 'strips full-line comments from source files'
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# This is a comment
+echo hello
+# Another comment
+echo world
+EOF
+
+			When run script ./bundle.sh --strip-comments "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'echo hello'
+			The output should include 'echo world'
+			The output should not include 'This is a comment'
+			The output should not include 'Another comment'
+		End
+
+		It 'preserves shebang'
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# comment
+echo hello
+EOF
+
+			When run script ./bundle.sh --strip-comments "$TEST_DIR/entry.sh"
+			The status should be success
+			The line 1 of output should equal '#!/bin/bash'
+		End
+
+		It 'preserves inline comments on code lines'
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+echo hello # inline comment
+EOF
+
+			When run script ./bundle.sh --strip-comments "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'echo hello # inline comment'
+		End
+
+		It 'strips comments from inlined source files'
+			cat > "$TEST_DIR/lib.sh" << 'EOF'
+# lib comment
+LIB_VAR=yes
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh --strip-comments "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'LIB_VAR=yes'
+			The output should not include 'lib comment'
+		End
+
+		It 'works with short option -s'
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# comment
+echo hello
+EOF
+
+			When run script ./bundle.sh -s "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should not include '# comment'
+		End
+
+		It 'preserves bundle marker comments by default'
+			cat > "$TEST_DIR/lib.sh" << 'EOF'
+LIB_VAR=yes
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh --strip-comments "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include '# --- begin:'
+			The output should include '# --- end:'
+		End
+	End
+
+	Describe '--hide-markers option'
+		It 'suppresses begin/end markers for inlined sources'
+			cat > "$TEST_DIR/lib.sh" << 'EOF'
+LIB_VAR=yes
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh --hide-markers "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'LIB_VAR=yes'
+			The output should not include '# --- begin:'
+			The output should not include '# --- end:'
+		End
+
+		It 'suppresses skipped markers for duplicates'
+			echo 'ONCE=yes' > "$TEST_DIR/lib.sh"
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle source
+. ./lib.sh
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh --hide-markers "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should not include '# --- skipped'
+		End
+
+		It 'suppresses markers for @bundle cmd output'
+			echo '#!/bin/bash' > "$TEST_DIR/entry.sh"
+			echo '# @bundle cmd echo "GENERATED"' >> "$TEST_DIR/entry.sh"
+			echo 'SKIPPED=yes' >> "$TEST_DIR/entry.sh"
+			echo '# @bundle end' >> "$TEST_DIR/entry.sh"
+
+			When run script ./bundle.sh --hide-markers "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'GENERATED'
+			The output should not include '# --- begin:'
+			The output should not include '# --- end:'
+		End
+
+		It 'suppresses keep markers'
+			cat > "$TEST_DIR/mockgen" << 'SCRIPT'
+#!/bin/bash
+echo "GENERATED"
+SCRIPT
+			chmod +x "$TEST_DIR/mockgen"
+			cat > "$TEST_DIR/opts.sh" << 'EOF'
+# @bundle keep
+VERSION=1.0
+# @bundle end
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle cmd ./mockgen -f ./opts.sh
+skipped
+# @bundle end
+EOF
+
+			When run script ./bundle.sh --hide-markers "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'VERSION=1.0'
+			The output should not include '# --- keep from:'
+		End
+
+		It 'works with short option -n'
+			cat > "$TEST_DIR/lib.sh" << 'EOF'
+LIB_VAR=yes
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh -n "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should not include '# ---'
+		End
+
+		It 'combines with --strip-comments'
+			cat > "$TEST_DIR/lib.sh" << 'EOF'
+# lib comment
+LIB_VAR=yes
+EOF
+			cat > "$TEST_DIR/entry.sh" << 'EOF'
+#!/bin/bash
+# entry comment
+# @bundle source
+. ./lib.sh
+EOF
+
+			When run script ./bundle.sh --strip-comments --hide-markers "$TEST_DIR/entry.sh"
+			The status should be success
+			The output should include 'LIB_VAR=yes'
+			The output should not include '# lib comment'
+			The output should not include '# entry comment'
+			The output should not include '# ---'
 		End
 	End
 End


### PR DESCRIPTION
## Summary

Add getoptions-based argument parsing to `bundle.sh` with two new options:
- `-s, --strip-comments`: Strip full-line comments from source files
- `-n, --hide-markers`: Suppress bundle marker comments (`# --- begin/end ---`)

Uses getoptions at runtime since bundle.sh runs in nix shell environment.

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)