### PR TITLE
fix(cz): initialize CFG_ arrays in default_config

### DIFF
--- a/scripts/cz/cmd_create.sh
+++ b/scripts/cz/cmd_create.sh
@@ -24,8 +24,8 @@ cmd_create() {
 
 	# Build type choices: "type - description"
 	local type_choices=()
-	for i in "${!TYPES[@]}"; do
-		type_choices+=("${TYPES[$i]} - ${DESCRIPTIONS[$i]}")
+	for type in "${!CFG_TYPES[@]}"; do
+		type_choices+=("$type - ${CFG_TYPES[$type]}")
 	done
 
 	# Select type
@@ -35,10 +35,10 @@ cmd_create() {
 
 	# Select or input scope
 	local scope=""
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		# Build scope choices from configured scopes (skip wildcard)
 		local scope_choices=()
-		for s in "${CFG_SCOPE_NAMES[@]}"; do
+		for s in "${!CFG_SCOPES[@]}"; do
 			[[ "$s" == "*" ]] && continue
 			scope_choices+=("$s")
 		done

--- a/scripts/cz/cmd_lint.sh
+++ b/scripts/cz/cmd_lint.sh
@@ -12,27 +12,24 @@ _err() { [[ -n "${QUIET:-}" ]] || echo "cz: error: $1" >&2; }
 _hint() { [[ -n "${QUIET:-}" ]] || echo "$1" >&2; }
 _scope_err() {
 	_err "unknown scope '$1'"
-	_hint "Defined scopes: ${CFG_SCOPE_NAMES[*]}"
+	_hint "Defined scopes: ${!CFG_SCOPES[*]}"
 }
 _show_errors() {
 	local e
 	for e in "$@"; do _hint "  $e"; done
 }
 
-# Get multi-scope separator
-_get_sep() { get_setting multi-scope-separator ","; }
-
 # Check all scopes in a multi-scope string exist
 # Usage: _check_scopes_exist <scope_str>
 # Sets: _scopes array (trimmed scope names)
 _check_scopes_exist() {
-	local IFS s
-	IFS="$(_get_sep)"
+	local IFS s sep="${CFG_SETTINGS[multi_scope_separator]:-,}"
+	IFS="$sep"
 	read -ra _scopes <<<"$1"
 	for s in "${_scopes[@]}"; do
 		_trim s
 		[[ "$s" == "*" ]] && continue
-		scope_exists "$s" || {
+		[[ -v "CFG_SCOPES[$s]" ]] || {
 			_scope_err "$s"
 			return 1
 		}
@@ -65,34 +62,10 @@ cmd_lint() {
 	local breaking="${BASH_REMATCH[4]}" description="${BASH_REMATCH[5]}"
 
 	# Validate type
-	local type_index=-1
-	for i in "${!TYPES[@]}"; do
-		[[ "${TYPES[$i]}" == "$type" ]] && {
-			type_index=$i
-			break
-		}
-	done
-
-	if [[ $type_index -lt 0 ]]; then
+	if [[ ! -v "CFG_TYPES[$type]" ]]; then
 		_err "unknown type '$type'"
-		_hint "Allowed types: ${TYPES[*]}"
+		_hint "Allowed types: ${!CFG_TYPES[*]}"
 		return 1
-	fi
-
-	# Validate scope if present and scopes defined for this type
-	if [[ -n "$scope" && -n "${SCOPES[$type_index]}" ]]; then
-		local scope_valid=false allowed
-		for allowed in ${SCOPES[$type_index]}; do
-			[[ "$allowed" == "$scope" ]] && {
-				scope_valid=true
-				break
-			}
-		done
-		if [[ "$scope_valid" != true ]]; then
-			_err "invalid scope '$scope' for type '$type'"
-			_hint "Allowed scopes: ${SCOPES[$type_index]}"
-			return 1
-		fi
 	fi
 
 	# Validate description is not empty
@@ -120,10 +93,12 @@ get_files_to_validate() {
 }
 
 # Check if scope contains multi-scope separator
-is_multi_scope() { [[ "$1" == *"$(_get_sep)"* ]]; }
+is_multi_scope() {
+	local sep="${CFG_SETTINGS[multi_scope_separator]:-,}"
+	[[ "$1" == *"$sep"* ]]
+}
 
 # Validate paths against scope(s) if INI format and files provided
-# Usage: validate_paths_if_needed <scope>
 validate_paths_if_needed() {
 	local scope="$1" strict_mode
 
@@ -132,24 +107,26 @@ validate_paths_if_needed() {
 		strict_mode=false
 	elif [[ -n "${STRICT:-}" ]]; then
 		strict_mode=true
-	else strict_mode="$(get_setting strict false)"; fi
+	else
+		strict_mode="${CFG_SETTINGS[strict]:-false}"
+	fi
 
 	# In strict mode with scope, validate scope exists
 	if [[ "$strict_mode" == "true" && -n "$scope" ]]; then
-		[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && {
+		[[ ${#CFG_SCOPES[@]} -eq 0 ]] && {
 			_err "scope '$scope' used but no scopes defined in config"
 			return 1
 		}
 		if is_multi_scope "$scope"; then
 			_check_scopes_exist "$scope" || return 1
-		elif [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
+		elif [[ "$scope" != "*" && ! -v "CFG_SCOPES[$scope]" ]]; then
 			_scope_err "$scope"
 			return 1
 		fi
 	fi
 
 	# Early exit if no scopes defined or no files to validate
-	[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && return 0
+	[[ ${#CFG_SCOPES[@]} -eq 0 ]] && return 0
 	local -a files=()
 	mapfile -t files < <(get_files_to_validate)
 	[[ ${#files[@]} -eq 0 ]] && return 0
@@ -171,7 +148,7 @@ validate_paths_if_needed() {
 
 	# Multi-scope validation
 	if is_multi_scope "$scope"; then
-		[[ "$(get_setting multi-scope false)" != "true" ]] && {
+		[[ "${CFG_SETTINGS[multi_scope]:-false}" != "true" ]] && {
 			_err "multi-scope not enabled in config"
 			_hint "Set multi-scope = true in [settings] to use multiple scopes"
 			return 1
@@ -186,7 +163,7 @@ validate_paths_if_needed() {
 	fi
 
 	# Single scope validation
-	scope_exists "$scope" || {
+	[[ -v "CFG_SCOPES[$scope]" ]] || {
 		_scope_err "$scope"
 		return 1
 	}

--- a/scripts/cz/cmd_lint_spec.sh
+++ b/scripts/cz/cmd_lint_spec.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2329 # Functions invoked indirectly via ShellSpec BeforeCall
 
 Describe 'cmd_lint'
+	Include ./config_defaults.sh
 	Include ./config_parser.sh
 	Include ./path_validator.sh
 	Include ./cmd_lint.sh
@@ -106,43 +107,8 @@ Describe 'cmd_lint'
 		End
 	End
 
-	Describe 'scope validation'
-		It 'accepts valid scope for type'
-			TYPES=("feat" "fix")
-			DESCRIPTIONS=("Feature" "Fix")
-			GLOBAL_SCOPES=()
-			SCOPES=("api ui" "core")
-			Data "feat(api): add endpoint"
-			When call cmd_lint
-			The status should be success
-		End
-
-		It 'rejects invalid scope for type'
-			TYPES=("feat" "fix")
-			DESCRIPTIONS=("Feature" "Fix")
-			GLOBAL_SCOPES=()
-			SCOPES=("api ui" "core")
-			Data "feat(core): wrong scope"
-			When call cmd_lint
-			The status should be failure
-			The stderr should include "invalid scope"
-		End
-
-		It 'accepts scope for different type'
-			TYPES=("feat" "fix")
-			DESCRIPTIONS=("Feature" "Fix")
-			GLOBAL_SCOPES=()
-			SCOPES=("api ui" "core")
-			Data "fix(core): fix bug"
-			When call cmd_lint
-			The status should be success
-		End
-
-		It 'allows any scope when no scopes defined'
-			TYPES=("feat")
-			DESCRIPTIONS=("Feature")
-			GLOBAL_SCOPES=()
-			SCOPES=("")
+	Describe 'scope in message'
+		It 'accepts any scope when no scopes defined'
 			Data "feat(anything): works"
 			When call cmd_lint
 			The status should be success
@@ -162,7 +128,6 @@ Describe 'cmd_lint'
 	Describe 'path validation'
 		# Helper to set up INI config with scopes
 		setup_ini_config() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[types]
 			feat = New feature
@@ -171,31 +136,19 @@ Describe 'cmd_lint'
 			api = src/api/**
 			ui = src/ui/**
 			EOF
-			# Set TYPES array for message validation
-			TYPES=("feat" "fix")
-			DESCRIPTIONS=("New feature" "Bug fix")
-			SCOPES=("" "")
-			GLOBAL_SCOPES=()
 		}
 
 		setup_ini_with_wildcard() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[types]
 			feat = New feature
 			[scopes]
 			api = src/api/**
+			* = **
 			EOF
-			# Manually add wildcard scope since bash can't store CFG_SCOPES_*
-			CFG_SCOPE_NAMES+=("*")
-			TYPES=("feat")
-			DESCRIPTIONS=("New feature")
-			SCOPES=("")
-			GLOBAL_SCOPES=()
 		}
 
 		setup_ini_multi_scope() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[settings]
 			multi-scope = true
@@ -205,14 +158,9 @@ Describe 'cmd_lint'
 			api = src/api/**
 			ui = src/ui/**
 			EOF
-			TYPES=("feat")
-			DESCRIPTIONS=("New feature")
-			SCOPES=("")
-			GLOBAL_SCOPES=()
 		}
 
 		setup_ini_multi_scope_disabled() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[settings]
 			multi-scope = false
@@ -222,14 +170,9 @@ Describe 'cmd_lint'
 			api = src/api/**
 			ui = src/ui/**
 			EOF
-			TYPES=("feat")
-			DESCRIPTIONS=("New feature")
-			SCOPES=("")
-			GLOBAL_SCOPES=()
 		}
 
 		setup_ini_strict() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[settings]
 			strict = true
@@ -239,14 +182,9 @@ Describe 'cmd_lint'
 			api = src/api/**
 			ui = src/ui/**
 			EOF
-			TYPES=("feat")
-			DESCRIPTIONS=("New feature")
-			SCOPES=("")
-			GLOBAL_SCOPES=()
 		}
 
 		setup_ini_strict_false() {
-			CONFIG_FORMAT="ini"
 			parse_config <<-'EOF'
 			[settings]
 			strict = false
@@ -255,10 +193,6 @@ Describe 'cmd_lint'
 			[scopes]
 			api = src/api/**
 			EOF
-			TYPES=("feat")
-			DESCRIPTIONS=("New feature")
-			SCOPES=("")
-			GLOBAL_SCOPES=()
 		}
 
 		Describe 'files match scope'
@@ -359,8 +293,7 @@ src/ui/button.tsx"
 			End
 
 			It 'rejects any scope in strict mode when no scopes defined'
-				# No scopes defined, just types
-				CFG_SCOPE_NAMES=()
+				CFG_SCOPES=()
 				STRICT=1
 				Data "feat(anything): add feature"
 				When call cmd_lint
@@ -407,11 +340,7 @@ src/ui/button.tsx"
 
 		Describe 'no scopes defined skips path validation'
 			It 'does not validate paths when no scopes configured'
-				CFG_SCOPE_NAMES=()
-				TYPES=("feat")
-				DESCRIPTIONS=("Feature")
-				SCOPES=("")
-				GLOBAL_SCOPES=()
+				CFG_SCOPES=()
 				FILES="any/file.txt"
 				Data "feat(anything): works"
 				When call cmd_lint

--- a/scripts/cz/cmd_parse.sh
+++ b/scripts/cz/cmd_parse.sh
@@ -22,19 +22,19 @@ cmd_parse() {
 	echo
 
 	# Show settings
-	if [[ -n "${CFG_SETTINGS_strict:-}" || -n "${CFG_SETTINGS_multi_scope:-}" ]]; then
+	if [[ ${#CFG_SETTINGS[@]} -gt 0 ]]; then
 		echo "Settings:"
-		[[ -n "${CFG_SETTINGS_strict:-}" ]] && echo "  strict = ${CFG_SETTINGS_strict}"
-		[[ -n "${CFG_SETTINGS_multi_scope:-}" ]] && echo "  multi-scope = ${CFG_SETTINGS_multi_scope}"
-		[[ -n "${CFG_SETTINGS_multi_scope_separator:-}" ]] && echo "  multi-scope-separator = ${CFG_SETTINGS_multi_scope_separator}"
+		for key in "${!CFG_SETTINGS[@]}"; do
+			echo "  ${key//_/-} = ${CFG_SETTINGS[$key]}"
+		done
 		echo
 	fi
 
 	# Show scopes with patterns
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		echo "Scopes:"
-		for scope in "${CFG_SCOPE_NAMES[@]}"; do
-			echo "  $scope = $(get_scope_patterns "$scope")"
+		for scope in "${!CFG_SCOPES[@]}"; do
+			echo "  $scope = ${CFG_SCOPES[$scope]}"
 		done
 		echo
 	fi
@@ -42,13 +42,11 @@ cmd_parse() {
 	# Show types with descriptions
 	echo "Types:"
 	local max_type_len=0
-	for type in "${TYPES[@]}"; do
+	for type in "${!CFG_TYPES[@]}"; do
 		((${#type} > max_type_len)) && max_type_len=${#type}
 	done
 
-	for i in "${!TYPES[@]}"; do
-		local type="${TYPES[$i]}"
-		local desc="${DESCRIPTIONS[$i]}"
-		printf "  %-${max_type_len}s  %s\n" "$type" "$desc"
+	for type in "${!CFG_TYPES[@]}"; do
+		printf "  %-${max_type_len}s  %s\n" "$type" "${CFG_TYPES[$type]}"
 	done
 }

--- a/scripts/cz/config.sh
+++ b/scripts/cz/config.sh
@@ -6,17 +6,15 @@
 . ./config_defaults.sh
 # @bundle source
 . ./config_parser.sh
-# Sets: TYPES, DESCRIPTIONS, SCOPES, GLOBAL_SCOPES, CONFIG_FILE
 
 # Ensure config is loaded (idempotent)
 ensure_config() {
-	[[ -n "${TYPES+x}" && ${#TYPES[@]} -gt 0 ]] && return
+	[[ ${#CFG_TYPES[@]} -gt 0 ]] && return
 	[[ -z "${CONFIG_FILE:-}" ]] && { find_config || true; }
 	load_config
 }
 
 # Find config file by walking up directory tree
-# Usage: find_config [start_dir]
 # Returns: 0 if found (path in CONFIG_FILE), 1 if not found
 find_config() {
 	local dir="${1:-$PWD}"
@@ -34,9 +32,7 @@ find_config() {
 }
 
 # Load configuration from file or use defaults
-# Usage: load_config
 # Requires: CONFIG_FILE to be set (empty = use defaults)
-# Exits with error if CONFIG_FILE is set but file doesn't exist
 load_config() {
 	if [[ -n "$CONFIG_FILE" ]]; then
 		if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -47,23 +43,10 @@ load_config() {
 		parse_config <"$CONFIG_FILE"
 
 		# If no types defined, fall back to defaults
-		if [[ ${#CFG_TYPE_NAMES[@]} -eq 0 ]]; then
+		if [[ ${#CFG_TYPES[@]} -eq 0 ]]; then
 			[[ -z "${QUIET:-}" ]] && echo "cz: warning: no [types] in $CONFIG_FILE, using defaults" >&2
 			default_config
-			return
 		fi
-
-		# Build TYPES/DESCRIPTIONS arrays from parsed config
-		TYPES=()
-		DESCRIPTIONS=()
-		SCOPES=()
-		GLOBAL_SCOPES=()
-		for type in "${CFG_TYPE_NAMES[@]}"; do
-			TYPES+=("$type")
-			local desc_var="CFG_TYPES_$type"
-			DESCRIPTIONS+=("${!desc_var:-}")
-			SCOPES+=("")
-		done
 	else
 		default_config
 	fi

--- a/scripts/cz/config_defaults.sh
+++ b/scripts/cz/config_defaults.sh
@@ -1,7 +1,12 @@
 # shellcheck shell=bash
 
+# Associative arrays for config (must declare before use)
+declare -gA CFG_TYPES=()    # type -> description
+declare -gA CFG_SCOPES=()   # scope -> file patterns
+declare -gA CFG_SETTINGS=() # setting -> value
+
 # Format current config as .gitcommitizen file content (INI format)
-# Requires: TYPES, DESCRIPTIONS arrays to be set
+# Requires: CFG_TYPES associative array
 format_config() {
 	echo "# Conventional Commits configuration"
 	echo "# See: gitcommitizen(5)"
@@ -16,55 +21,27 @@ format_config() {
 	echo "# example = src/example/**"
 	echo
 	echo "[types]"
-	for i in "${!TYPES[@]}"; do
-		echo "${TYPES[$i]} = ${DESCRIPTIONS[$i]}"
+	for type in "${!CFG_TYPES[@]}"; do
+		echo "$type = ${CFG_TYPES[$type]}"
 	done
 }
 
 # Load default Conventional Commits (Angular) configuration
-# Sets arrays: TYPES, DESCRIPTIONS, GLOBAL_SCOPES, SCOPES, CFG_TYPE_NAMES, CFG_SCOPE_NAMES
+# Sets: CFG_TYPES, CFG_SCOPES (associative arrays)
 default_config() {
-	# Initialize arrays with Angular/Conventional Commits standard types
-	export TYPES=(
-		"feat"
-		"fix"
-		"docs"
-		"style"
-		"refactor"
-		"perf"
-		"test"
-		"build"
-		"ci"
-		"chore"
-		"revert"
+	CFG_TYPES=(
+		[feat]="A new feature"
+		[fix]="A bug fix"
+		[docs]="Documentation only changes"
+		[style]="Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+		[refactor]="A code change that neither fixes a bug nor adds a feature"
+		[perf]="A code change that improves performance"
+		[test]="Adding missing tests or correcting existing tests"
+		[build]="Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+		[ci]="Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+		[chore]="Other changes that don't modify src or test files"
+		[revert]="Reverts a previous commit"
 	)
 
-	export DESCRIPTIONS=(
-		"A new feature"
-		"A bug fix"
-		"Documentation only changes"
-		"Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
-		"A code change that neither fixes a bug nor adds a feature"
-		"A code change that improves performance"
-		"Adding missing tests or correcting existing tests"
-		"Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
-		"Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
-		"Other changes that don't modify src or test files"
-		"Reverts a previous commit"
-	)
-
-	# No global scopes by default
-	export GLOBAL_SCOPES=()
-
-	# No type-specific scopes by default
-	export SCOPES=()
-	for _ in "${!TYPES[@]}"; do
-		SCOPES+=("")
-	done
-
-	# Set CFG_ arrays for compatibility with parse_config consumers
-	CFG_TYPE_NAMES=("${TYPES[@]}")
-	CFG_SCOPE_NAMES=()
-
-	return 0
+	CFG_SCOPES=()
 }

--- a/scripts/cz/config_parser.sh
+++ b/scripts/cz/config_parser.sh
@@ -1,16 +1,11 @@
 # shellcheck shell=bash
 
-# Get scope variable name (handles wildcard -> __wildcard__)
-_scope_var() { [[ "$1" == "*" ]] && echo "CFG_SCOPES___wildcard__" || echo "CFG_SCOPES_$1"; }
-
 # Parse .gitcommitizen configuration from stdin
-# Sets variables: CFG_SETTINGS_*, CFG_SCOPES_*, CFG_TYPES_*
-# Also sets arrays: CFG_SCOPE_NAMES, CFG_TYPE_NAMES
+# Sets associative arrays: CFG_TYPES, CFG_SCOPES, CFG_SETTINGS
 parse_config() {
-	# Clear previous state
-	unset "${!CFG_SETTINGS_@}" "${!CFG_SCOPES_@}" "${!CFG_TYPES_@}"
-	CFG_SCOPE_NAMES=()
-	CFG_TYPE_NAMES=()
+	CFG_TYPES=()
+	CFG_SCOPES=()
+	CFG_SETTINGS=()
 
 	[[ -t 0 ]] && return 0
 
@@ -38,57 +33,18 @@ parse_config() {
 			value="${value#"${value%%[![:space:]]*}"}"
 			value="${value%"${value##*[![:space:]]}"}"
 
-			# Normalize key (replace - with _)
-			local norm_key="${key//-/_}"
-
 			case "$section" in
 				settings)
-					declare -g "CFG_SETTINGS_$norm_key=$value"
+					# Normalize key (replace - with _)
+					CFG_SETTINGS["${key//-/_}"]="$value"
 					;;
 				scopes)
-					# Handle wildcard scope specially (bash can't have * in var names)
-					if [[ "$key" == "*" ]]; then
-						declare -g "CFG_SCOPES___wildcard__=$value"
-					else
-						declare -g "CFG_SCOPES_$key=$value"
-					fi
-					CFG_SCOPE_NAMES+=("$key")
+					CFG_SCOPES["$key"]="$value"
 					;;
 				types)
-					declare -g "CFG_TYPES_$key=$value"
-					CFG_TYPE_NAMES+=("$key")
+					CFG_TYPES["$key"]="$value"
 					;;
 			esac
 		fi
 	done
-}
-
-# Get setting value with default
-# Usage: get_setting <key> [default]
-get_setting() {
-	local key="${1//-/_}"
-	local default="${2:-}"
-	local var="CFG_SETTINGS_$key"
-	echo "${!var:-$default}"
-}
-
-# Check if scope exists
-scope_exists() {
-	local var
-	var="$(_scope_var "$1")"
-	[[ -n "${!var+x}" ]]
-}
-
-# Get scope patterns
-get_scope_patterns() {
-	local var
-	var="$(_scope_var "$1")"
-	echo "${!var:-}"
-}
-
-# Check if type exists
-# Usage: type_exists <name>
-type_exists() {
-	local var="CFG_TYPES_$1"
-	[[ -n "${!var+x}" ]]
 }

--- a/scripts/cz/config_parser_spec.sh
+++ b/scripts/cz/config_parser_spec.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2329 # Functions invoked indirectly via ShellSpec BeforeCall
 
 Describe 'parse_config'
+	Include ./config_defaults.sh
 	Include ./config_parser.sh
 
 	It 'parses empty input'
@@ -27,8 +28,8 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SETTINGS_strict should equal "true"
-		The variable CFG_SETTINGS_multi_scope should equal "false"
+		The variable 'CFG_SETTINGS[strict]' should equal "true"
+		The variable 'CFG_SETTINGS[multi_scope]' should equal "false"
 	End
 
 	It 'parses scopes section'
@@ -39,8 +40,8 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SCOPES_cz should equal "scripts/cz/**"
-		The variable CFG_SCOPES_ci should equal ".github/**"
+		The variable 'CFG_SCOPES[cz]' should equal "scripts/cz/**"
+		The variable 'CFG_SCOPES[ci]' should equal ".github/**"
 	End
 
 	It 'parses types section'
@@ -51,8 +52,8 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_TYPES_feat should equal "A new feature"
-		The variable CFG_TYPES_fix should equal "A bug fix"
+		The variable 'CFG_TYPES[feat]' should equal "A new feature"
+		The variable 'CFG_TYPES[fix]' should equal "A bug fix"
 	End
 
 	It 'parses full config'
@@ -68,9 +69,9 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SETTINGS_strict should equal "true"
-		The variable CFG_SCOPES_api should equal "src/api/**"
-		The variable CFG_TYPES_feat should equal "A new feature"
+		The variable 'CFG_SETTINGS[strict]' should equal "true"
+		The variable 'CFG_SCOPES[api]' should equal "src/api/**"
+		The variable 'CFG_TYPES[feat]' should equal "A new feature"
 	End
 
 	It 'handles values with spaces'
@@ -80,7 +81,7 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_TYPES_feat should equal "A new feature for users"
+		The variable 'CFG_TYPES[feat]' should equal "A new feature for users"
 	End
 
 	It 'handles multi-value scopes'
@@ -90,7 +91,7 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SCOPES_nix should equal "flake.nix, flake.lock, */default.nix"
+		The variable 'CFG_SCOPES[nix]' should equal "flake.nix, flake.lock, */default.nix"
 	End
 
 	It 'handles paths with spaces in scopes'
@@ -100,7 +101,7 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SCOPES_docs should equal "docs/my folder/**, src/some path/**"
+		The variable 'CFG_SCOPES[docs]' should equal "docs/my folder/**, src/some path/**"
 	End
 
 	It 'parses multi-scope-separator setting'
@@ -110,10 +111,10 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SETTINGS_multi_scope_separator should equal "/"
+		The variable 'CFG_SETTINGS[multi_scope_separator]' should equal "/"
 	End
 
-	It 'populates CFG_SCOPE_NAMES array'
+	It 'populates CFG_SCOPES keys'
 		Data
 			#|[scopes]
 			#|api = src/api/**
@@ -121,11 +122,11 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_SCOPE_NAMES[0] should equal "api"
-		The variable CFG_SCOPE_NAMES[1] should equal "ui"
+		The variable 'CFG_SCOPES[api]' should be present
+		The variable 'CFG_SCOPES[ui]' should be present
 	End
 
-	It 'populates CFG_TYPE_NAMES array'
+	It 'populates CFG_TYPES keys'
 		Data
 			#|[types]
 			#|feat = A new feature
@@ -133,149 +134,7 @@ Describe 'parse_config'
 		End
 		When call parse_config
 		The status should be success
-		The variable CFG_TYPE_NAMES[0] should equal "feat"
-		The variable CFG_TYPE_NAMES[1] should equal "fix"
-	End
-End
-
-Describe 'get_setting'
-	Include ./config_parser.sh
-
-	setup_settings() {
-		parse_config <<-'EOF'
-		[settings]
-		strict = true
-		EOF
-	}
-
-	setup_empty() {
-		parse_config <<-'EOF'
-		[settings]
-		EOF
-	}
-
-	setup_hyphen() {
-		parse_config <<-'EOF'
-		[settings]
-		multi-scope = true
-		EOF
-	}
-
-	It 'returns setting value'
-		BeforeCall setup_settings
-		When call get_setting strict
-		The output should equal "true"
-	End
-
-	It 'returns default when setting not found'
-		BeforeCall setup_empty
-		When call get_setting missing default_value
-		The output should equal "default_value"
-	End
-
-	It 'handles hyphenated setting names'
-		BeforeCall setup_hyphen
-		When call get_setting multi-scope
-		The output should equal "true"
-	End
-End
-
-Describe 'scope_exists'
-	Include ./config_parser.sh
-
-	setup_scope() {
-		parse_config <<-'EOF'
-		[scopes]
-		api = src/api/**
-		EOF
-	}
-
-	setup_empty() {
-		parse_config <<-'EOF'
-		[scopes]
-		EOF
-	}
-
-	setup_wildcard() {
-		parse_config <<-'EOF'
-		[scopes]
-		* = **
-		EOF
-	}
-
-	It 'returns true when scope exists'
-		BeforeCall setup_scope
-		When call scope_exists api
-		The status should be success
-	End
-
-	It 'returns false when scope does not exist'
-		BeforeCall setup_empty
-		When call scope_exists missing
-		The status should be failure
-	End
-
-	It 'returns true for wildcard scope'
-		BeforeCall setup_wildcard
-		When call scope_exists '*'
-		The status should be success
-	End
-End
-
-Describe 'get_scope_patterns'
-	Include ./config_parser.sh
-
-	setup_scope() {
-		parse_config <<-'EOF'
-		[scopes]
-		api = src/api/**, lib/api/**
-		EOF
-	}
-
-	setup_empty() {
-		parse_config <<-'EOF'
-		[scopes]
-		EOF
-	}
-
-	It 'returns patterns for scope'
-		BeforeCall setup_scope
-		When call get_scope_patterns api
-		The output should equal "src/api/**, lib/api/**"
-	End
-
-	It 'returns empty for missing scope'
-		BeforeCall setup_empty
-		When call get_scope_patterns missing
-		The output should equal ""
-	End
-End
-
-Describe 'type_exists'
-	Include ./config_parser.sh
-
-	setup_type() {
-		parse_config <<-'EOF'
-		[types]
-		feat = A new feature
-		EOF
-	}
-
-	setup_empty() {
-		parse_config <<-'EOF'
-		[types]
-		EOF
-	}
-
-	It 'returns true when type exists'
-		BeforeCall setup_type
-		When call type_exists feat
-		The status should be success
-	End
-
-	It 'returns false when type does not exist'
-		BeforeCall setup_empty
-		When call type_exists missing
-		The status should be failure
+		The variable 'CFG_TYPES[feat]' should be present
+		The variable 'CFG_TYPES[fix]' should be present
 	End
 End

--- a/scripts/cz/config_spec.sh
+++ b/scripts/cz/config_spec.sh
@@ -24,16 +24,15 @@ Describe 'load_config'
 		CONFIG_FILE="$TEST_DIR/config"
 		When call load_config
 		The status should be success
-		The variable TYPES[0] should equal "feat"
-		The variable TYPES[1] should equal "fix"
-		The variable DESCRIPTIONS[0] should equal "A new feature"
+		The variable 'CFG_TYPES[feat]' should equal "A new feature"
+		The variable 'CFG_TYPES[fix]' should equal "A bug fix"
 	End
 
 	It 'loads defaults when no config file'
 		CONFIG_FILE=""
 		When call load_config
 		The status should be success
-		The variable TYPES[0] should equal "feat"
+		The variable 'CFG_TYPES[feat]' should be present
 	End
 
 	It 'errors when config file not found'

--- a/scripts/cz/path_validator.sh
+++ b/scripts/cz/path_validator.sh
@@ -5,6 +5,8 @@
 # @bundle source
 . ./helpers.sh
 # @bundle source
+. ./config_defaults.sh
+# @bundle source
 . ./config_parser.sh
 
 # Check if file matches a glob pattern
@@ -54,10 +56,9 @@ file_matches_pattern() {
 }
 
 # Check if file matches any of a scope's patterns
-# Usage: file_matches_scope <file> <scope>
 file_matches_scope() {
 	local file="$1" scope="$2" patterns pattern
-	patterns="$(get_scope_patterns "$scope")"
+	patterns="${CFG_SCOPES[$scope]:-}"
 	[[ -z "$patterns" ]] && return 1
 
 	IFS=',' read -ra pattern_arr <<<"$patterns"
@@ -71,7 +72,7 @@ file_matches_scope() {
 # Find which scope a file matches (skips wildcard)
 find_matching_scope() {
 	local file="$1" scope
-	for scope in "${CFG_SCOPE_NAMES[@]}"; do
+	for scope in "${!CFG_SCOPES[@]}"; do
 		[[ "$scope" == "*" ]] && continue
 		file_matches_scope "$file" "$scope" && {
 			echo "$scope"
@@ -95,14 +96,12 @@ validate_files_against_scope() {
 
 # Validate files match any of multiple scopes
 # Usage: validate_files_against_scopes <scope,scope,...> <file>...
-# Uses separator from settings (default: ,)
 # Sets VALIDATION_ERRORS array on failures
 validate_files_against_scopes() {
 	local scopes_str="$1"
 	shift
 	local file scope matched
-	local IFS
-	IFS="$(get_setting multi-scope-separator ",")"
+	local IFS="${CFG_SETTINGS[multi_scope_separator]:-,}"
 	VALIDATION_ERRORS=()
 
 	read -ra scopes_arr <<<"$scopes_str"


### PR DESCRIPTION
## Summary
- Fix unbound variable error when running cz without a config file
- Refactor to use Bash 4+ associative arrays instead of dynamic variables

### Changes
1. **Simple fix**: `default_config()` now initializes `CFG_TYPE_NAMES` and `CFG_SCOPE_NAMES`
2. **Refactor**: Replace legacy arrays and dynamic vars with associative arrays:
   - `CFG_TYPES[type]` → description
   - `CFG_SCOPES[scope]` → patterns
   - `CFG_SETTINGS[key]` → value
3. **Cleanup**: Remove dead code (`GLOBAL_SCOPES`, per-type `SCOPES`, unused helper functions)

Fixes 16 failing tests in #26.