### PR TITLE
refactor(cz): use associative arrays for config storage

### DIFF
--- a/dist/cz/bin/cz
+++ b/dist/cz/bin/cz
@@ -146,7 +146,7 @@ GETOPTIONSHERE
 # shellcheck shell=bash
 
 # Format current config as .gitcommitizen file content (INI format)
-# Requires: TYPES, DESCRIPTIONS arrays to be set
+# Requires: CFG_TYPES associative array to be set
 format_config() {
 	echo "# Conventional Commits configuration"
 	echo "# See: gitcommitizen(5)"
@@ -161,75 +161,47 @@ format_config() {
 	echo "# example = src/example/**"
 	echo
 	echo "[types]"
-	for i in "${!TYPES[@]}"; do
-		echo "${TYPES[$i]} = ${DESCRIPTIONS[$i]}"
+	local type
+	for type in "${!CFG_TYPES[@]}"; do
+		echo "$type = ${CFG_TYPES[$type]}"
 	done
 }
 
 # Load default Conventional Commits (Angular) configuration
-# Sets arrays: TYPES, DESCRIPTIONS, GLOBAL_SCOPES, SCOPES, CFG_TYPE_NAMES, CFG_SCOPE_NAMES
+# Sets associative arrays: CFG_TYPES, CFG_SCOPES, CFG_SETTINGS
 default_config() {
-	# Initialize arrays with Angular/Conventional Commits standard types
-	export TYPES=(
-		"feat"
-		"fix"
-		"docs"
-		"style"
-		"refactor"
-		"perf"
-		"test"
-		"build"
-		"ci"
-		"chore"
-		"revert"
+	# Note: =() initialization required for set -u compatibility
+	unset CFG_TYPES CFG_SCOPES CFG_SETTINGS
+	# shellcheck disable=SC2034 # used by other modules
+	declare -gA CFG_SCOPES=() CFG_SETTINGS=()
+	declare -gA CFG_TYPES=(
+		[feat]="A new feature"
+		[fix]="A bug fix"
+		[docs]="Documentation only changes"
+		[style]="Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+		[refactor]="A code change that neither fixes a bug nor adds a feature"
+		[perf]="A code change that improves performance"
+		[test]="Adding missing tests or correcting existing tests"
+		[build]="Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+		[ci]="Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+		[chore]="Other changes that don't modify src or test files"
+		[revert]="Reverts a previous commit"
 	)
-
-	export DESCRIPTIONS=(
-		"A new feature"
-		"A bug fix"
-		"Documentation only changes"
-		"Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
-		"A code change that neither fixes a bug nor adds a feature"
-		"A code change that improves performance"
-		"Adding missing tests or correcting existing tests"
-		"Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
-		"Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
-		"Other changes that don't modify src or test files"
-		"Reverts a previous commit"
-	)
-
-	# No global scopes by default
-	export GLOBAL_SCOPES=()
-
-	# No type-specific scopes by default
-	export SCOPES=()
-	for _ in "${!TYPES[@]}"; do
-		SCOPES+=("")
-	done
-
-	# Set CFG_ arrays for compatibility with parse_config consumers
-	# shellcheck disable=SC2034 # used by config.sh consumers
-	CFG_TYPE_NAMES=("${TYPES[@]}")
-	# shellcheck disable=SC2034 # used by config.sh consumers
-	CFG_SCOPE_NAMES=()
 
 	return 0
 }
 # --- end: scripts/cz/config_defaults.sh ---
 # --- begin: scripts/cz/config_parser.sh ---
-# shellcheck shell=bash
-
-# Get scope variable name (handles wildcard -> __wildcard__)
-_scope_var() { [[ "$1" == "*" ]] && echo "CFG_SCOPES___wildcard__" || echo "CFG_SCOPES_$1"; }
+# shellcheck shell=bash disable=SC2034
 
 # Parse .gitcommitizen configuration from stdin
-# Sets variables: CFG_SETTINGS_*, CFG_SCOPES_*, CFG_TYPES_*
-# Also sets arrays: CFG_SCOPE_NAMES, CFG_TYPE_NAMES
+# Sets associative arrays: CFG_SETTINGS, CFG_SCOPES, CFG_TYPES
+# Note: SC2034 disabled - arrays are used by other modules
 parse_config() {
-	# Clear previous state
-	unset "${!CFG_SETTINGS_@}" "${!CFG_SCOPES_@}" "${!CFG_TYPES_@}"
-	CFG_SCOPE_NAMES=()
-	CFG_TYPE_NAMES=()
+	# Clear previous state and declare associative arrays
+	# Note: =() initialization required for set -u compatibility
+	unset CFG_SETTINGS CFG_SCOPES CFG_TYPES
+	declare -gA CFG_SETTINGS=() CFG_SCOPES=() CFG_TYPES=()
 
 	[[ -t 0 ]] && return 0
 
@@ -257,66 +229,27 @@ parse_config() {
 			value="${value#"${value%%[![:space:]]*}"}"
 			value="${value%"${value##*[![:space:]]}"}"
 
-			# Normalize key (replace - with _)
-			local norm_key="${key//-/_}"
-
 			case "$section" in
 				settings)
-					declare -g "CFG_SETTINGS_$norm_key=$value"
+					# Normalize key (replace - with _)
+					CFG_SETTINGS["${key//-/_}"]="$value"
 					;;
 				scopes)
-					# Handle wildcard scope specially (bash can't have * in var names)
-					if [[ "$key" == "*" ]]; then
-						declare -g "CFG_SCOPES___wildcard__=$value"
-					else
-						declare -g "CFG_SCOPES_$key=$value"
-					fi
-					CFG_SCOPE_NAMES+=("$key")
+					CFG_SCOPES["$key"]="$value"
 					;;
 				types)
-					declare -g "CFG_TYPES_$key=$value"
-					CFG_TYPE_NAMES+=("$key")
+					CFG_TYPES["$key"]="$value"
 					;;
 			esac
 		fi
 	done
 }
-
-# Get setting value with default
-# Usage: get_setting <key> [default]
-get_setting() {
-	local key="${1//-/_}"
-	local default="${2:-}"
-	local var="CFG_SETTINGS_$key"
-	echo "${!var:-$default}"
-}
-
-# Check if scope exists
-scope_exists() {
-	local var
-	var="$(_scope_var "$1")"
-	[[ -n "${!var+x}" ]]
-}
-
-# Get scope patterns
-get_scope_patterns() {
-	local var
-	var="$(_scope_var "$1")"
-	echo "${!var:-}"
-}
-
-# Check if type exists
-# Usage: type_exists <name>
-type_exists() {
-	local var="CFG_TYPES_$1"
-	[[ -n "${!var+x}" ]]
-}
 # --- end: scripts/cz/config_parser.sh ---
-# Sets: TYPES, DESCRIPTIONS, SCOPES, GLOBAL_SCOPES, CONFIG_FILE
+# Sets associative arrays: CFG_TYPES, CFG_SCOPES, CFG_SETTINGS
 
 # Ensure config is loaded (idempotent)
 ensure_config() {
-	[[ -n "${TYPES+x}" && ${#TYPES[@]} -gt 0 ]] && return
+	[[ -n "${CFG_TYPES+x}" && ${#CFG_TYPES[@]} -gt 0 ]] && return
 	[[ -z "${CONFIG_FILE:-}" ]] && { find_config || true; }
 	load_config
 }
@@ -352,24 +285,24 @@ load_config() {
 
 		parse_config <"$CONFIG_FILE"
 
-		# If no types defined, fall back to defaults
-		if [[ ${#CFG_TYPE_NAMES[@]} -eq 0 ]]; then
+		# If no types defined, use default types but preserve settings/scopes
+		if [[ ${#CFG_TYPES[@]} -eq 0 ]]; then
 			[[ -z "${QUIET:-}" ]] && echo "cz: warning: no [types] in $CONFIG_FILE, using defaults" >&2
-			default_config
-			return
+			# Only set default types, preserve parsed settings and scopes
+			declare -gA CFG_TYPES=(
+				[feat]="A new feature"
+				[fix]="A bug fix"
+				[docs]="Documentation only changes"
+				[style]="Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+				[refactor]="A code change that neither fixes a bug nor adds a feature"
+				[perf]="A code change that improves performance"
+				[test]="Adding missing tests or correcting existing tests"
+				[build]="Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+				[ci]="Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+				[chore]="Other changes that don't modify src or test files"
+				[revert]="Reverts a previous commit"
+			)
 		fi
-
-		# Build TYPES/DESCRIPTIONS arrays from parsed config
-		TYPES=()
-		DESCRIPTIONS=()
-		SCOPES=()
-		GLOBAL_SCOPES=()
-		for type in "${CFG_TYPE_NAMES[@]}"; do
-			TYPES+=("$type")
-			local desc_var="CFG_TYPES_$type"
-			DESCRIPTIONS+=("${!desc_var:-}")
-			SCOPES+=("")
-		done
 	else
 		default_config
 	fi
@@ -393,34 +326,33 @@ cmd_parse() {
 	echo
 
 	# Show settings
-	if [[ -n "${CFG_SETTINGS_strict:-}" || -n "${CFG_SETTINGS_multi_scope:-}" ]]; then
+	if [[ ${#CFG_SETTINGS[@]} -gt 0 ]]; then
 		echo "Settings:"
-		[[ -n "${CFG_SETTINGS_strict:-}" ]] && echo "  strict = ${CFG_SETTINGS_strict}"
-		[[ -n "${CFG_SETTINGS_multi_scope:-}" ]] && echo "  multi-scope = ${CFG_SETTINGS_multi_scope}"
-		[[ -n "${CFG_SETTINGS_multi_scope_separator:-}" ]] && echo "  multi-scope-separator = ${CFG_SETTINGS_multi_scope_separator}"
+		[[ -v CFG_SETTINGS[strict] ]] && echo "  strict = ${CFG_SETTINGS[strict]}"
+		[[ -v CFG_SETTINGS[multi_scope] ]] && echo "  multi-scope = ${CFG_SETTINGS[multi_scope]}"
+		[[ -v CFG_SETTINGS[multi_scope_separator] ]] && echo "  multi-scope-separator = ${CFG_SETTINGS[multi_scope_separator]}"
 		echo
 	fi
 
 	# Show scopes with patterns
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		echo "Scopes:"
-		for scope in "${CFG_SCOPE_NAMES[@]}"; do
-			echo "  $scope = $(get_scope_patterns "$scope")"
+		local scope
+		for scope in "${!CFG_SCOPES[@]}"; do
+			echo "  $scope = ${CFG_SCOPES[$scope]}"
 		done
 		echo
 	fi
 
 	# Show types with descriptions
 	echo "Types:"
-	local max_type_len=0
-	for type in "${TYPES[@]}"; do
+	local max_type_len=0 type
+	for type in "${!CFG_TYPES[@]}"; do
 		((${#type} > max_type_len)) && max_type_len=${#type}
 	done
 
-	for i in "${!TYPES[@]}"; do
-		local type="${TYPES[$i]}"
-		local desc="${DESCRIPTIONS[$i]}"
-		printf "  %-${max_type_len}s  %s\n" "$type" "$desc"
+	for type in "${!CFG_TYPES[@]}"; do
+		printf "  %-${max_type_len}s  %s\n" "$type" "${CFG_TYPES[$type]}"
 	done
 }
 # --- end: scripts/cz/cmd_parse.sh ---
@@ -631,7 +563,7 @@ file_matches_pattern() {
 # Usage: file_matches_scope <file> <scope>
 file_matches_scope() {
 	local file="$1" scope="$2" patterns pattern
-	patterns="$(get_scope_patterns "$scope")"
+	patterns="${CFG_SCOPES[$scope]:-}"
 	[[ -z "$patterns" ]] && return 1
 
 	IFS=',' read -ra pattern_arr <<<"$patterns"
@@ -645,7 +577,7 @@ file_matches_scope() {
 # Find which scope a file matches (skips wildcard)
 find_matching_scope() {
 	local file="$1" scope
-	for scope in "${CFG_SCOPE_NAMES[@]}"; do
+	for scope in "${!CFG_SCOPES[@]}"; do
 		[[ "$scope" == "*" ]] && continue
 		file_matches_scope "$file" "$scope" && {
 			echo "$scope"
@@ -676,7 +608,7 @@ validate_files_against_scopes() {
 	shift
 	local file scope matched
 	local IFS
-	IFS="$(get_setting multi-scope-separator ",")"
+	IFS="${CFG_SETTINGS[multi_scope_separator]:-,}"
 	VALIDATION_ERRORS=()
 
 	read -ra scopes_arr <<<"$scopes_str"
@@ -711,7 +643,7 @@ _err() { [[ -n "${QUIET:-}" ]] || echo "cz: error: $1" >&2; }
 _hint() { [[ -n "${QUIET:-}" ]] || echo "$1" >&2; }
 _scope_err() {
 	_err "unknown scope '$1'"
-	_hint "Defined scopes: ${CFG_SCOPE_NAMES[*]}"
+	_hint "Defined scopes: ${!CFG_SCOPES[*]}"
 }
 _show_errors() {
 	local e
@@ -719,7 +651,7 @@ _show_errors() {
 }
 
 # Get multi-scope separator
-_get_sep() { get_setting multi-scope-separator ","; }
+_get_sep() { echo "${CFG_SETTINGS[multi_scope_separator]:-,}"; }
 
 # Check all scopes in a multi-scope string exist
 # Usage: _check_scopes_exist <scope_str>
@@ -731,7 +663,7 @@ _check_scopes_exist() {
 	for s in "${_scopes[@]}"; do
 		_trim s
 		[[ "$s" == "*" ]] && continue
-		scope_exists "$s" || {
+		[[ -v CFG_SCOPES["$s"] ]] || {
 			_scope_err "$s"
 			return 1
 		}
@@ -764,34 +696,10 @@ cmd_lint() {
 	local breaking="${BASH_REMATCH[4]}" description="${BASH_REMATCH[5]}"
 
 	# Validate type
-	local type_index=-1
-	for i in "${!TYPES[@]}"; do
-		[[ "${TYPES[$i]}" == "$type" ]] && {
-			type_index=$i
-			break
-		}
-	done
-
-	if [[ $type_index -lt 0 ]]; then
+	if [[ ! -v CFG_TYPES["$type"] ]]; then
 		_err "unknown type '$type'"
-		_hint "Allowed types: ${TYPES[*]}"
+		_hint "Allowed types: ${!CFG_TYPES[*]}"
 		return 1
-	fi
-
-	# Validate scope if present and scopes defined for this type
-	if [[ -n "$scope" && -n "${SCOPES[$type_index]}" ]]; then
-		local scope_valid=false allowed
-		for allowed in ${SCOPES[$type_index]}; do
-			[[ "$allowed" == "$scope" ]] && {
-				scope_valid=true
-				break
-			}
-		done
-		if [[ "$scope_valid" != true ]]; then
-			_err "invalid scope '$scope' for type '$type'"
-			_hint "Allowed scopes: ${SCOPES[$type_index]}"
-			return 1
-		fi
 	fi
 
 	# Validate description is not empty
@@ -832,25 +740,25 @@ validate_paths_if_needed() {
 	elif [[ "${STRICT-unset}" == "" ]]; then
 		strict_mode=false
 	else
-		strict_mode="$(get_setting strict false)"
+		strict_mode="${CFG_SETTINGS[strict]:-false}"
 	fi
 
 	# In strict mode with scope, validate scope exists
 	if [[ "$strict_mode" == "true" && -n "$scope" ]]; then
-		[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && {
+		[[ ${#CFG_SCOPES[@]} -eq 0 ]] && {
 			_err "scope '$scope' used but no scopes defined in config"
 			return 1
 		}
 		if is_multi_scope "$scope"; then
 			_check_scopes_exist "$scope" || return 1
-		elif [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
+		elif [[ "$scope" != "*" && ! -v CFG_SCOPES["$scope"] ]]; then
 			_scope_err "$scope"
 			return 1
 		fi
 	fi
 
 	# Early exit if no scopes defined or no files to validate
-	[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && return 0
+	[[ ${#CFG_SCOPES[@]} -eq 0 ]] && return 0
 	local -a files=()
 	mapfile -t files < <(get_files_to_validate)
 	[[ ${#files[@]} -eq 0 ]] && return 0
@@ -872,7 +780,7 @@ validate_paths_if_needed() {
 
 	# Multi-scope validation
 	if is_multi_scope "$scope"; then
-		[[ "$(get_setting multi-scope false)" != "true" ]] && {
+		[[ "${CFG_SETTINGS[multi_scope]:-false}" != "true" ]] && {
 			_err "multi-scope not enabled in config"
 			_hint "Set multi-scope = true in [settings] to use multiple scopes"
 			return 1
@@ -887,7 +795,7 @@ validate_paths_if_needed() {
 	fi
 
 	# Single scope validation
-	scope_exists "$scope" || {
+	[[ -v CFG_SCOPES["$scope"] ]] || {
 		_scope_err "$scope"
 		return 1
 	}
@@ -923,9 +831,9 @@ cmd_create() {
 	ensure_config
 
 	# Build type choices: "type - description"
-	local type_choices=()
-	for i in "${!TYPES[@]}"; do
-		type_choices+=("${TYPES[$i]} - ${DESCRIPTIONS[$i]}")
+	local type_choices=() t
+	for t in "${!CFG_TYPES[@]}"; do
+		type_choices+=("$t - ${CFG_TYPES[$t]}")
 	done
 
 	# Select type
@@ -935,10 +843,10 @@ cmd_create() {
 
 	# Select or input scope
 	local scope=""
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		# Build scope choices from configured scopes (skip wildcard)
-		local scope_choices=()
-		for s in "${CFG_SCOPE_NAMES[@]}"; do
+		local scope_choices=() s
+		for s in "${!CFG_SCOPES[@]}"; do
 			[[ "$s" == "*" ]] && continue
 			scope_choices+=("$s")
 		done

--- a/scripts/cz/cmd_create.sh
+++ b/scripts/cz/cmd_create.sh
@@ -23,9 +23,9 @@ cmd_create() {
 	ensure_config
 
 	# Build type choices: "type - description"
-	local type_choices=()
-	for i in "${!TYPES[@]}"; do
-		type_choices+=("${TYPES[$i]} - ${DESCRIPTIONS[$i]}")
+	local type_choices=() t
+	for t in "${!CFG_TYPES[@]}"; do
+		type_choices+=("$t - ${CFG_TYPES[$t]}")
 	done
 
 	# Select type
@@ -35,10 +35,10 @@ cmd_create() {
 
 	# Select or input scope
 	local scope=""
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		# Build scope choices from configured scopes (skip wildcard)
-		local scope_choices=()
-		for s in "${CFG_SCOPE_NAMES[@]}"; do
+		local scope_choices=() s
+		for s in "${!CFG_SCOPES[@]}"; do
 			[[ "$s" == "*" ]] && continue
 			scope_choices+=("$s")
 		done

--- a/scripts/cz/cmd_lint.sh
+++ b/scripts/cz/cmd_lint.sh
@@ -12,7 +12,7 @@ _err() { [[ -n "${QUIET:-}" ]] || echo "cz: error: $1" >&2; }
 _hint() { [[ -n "${QUIET:-}" ]] || echo "$1" >&2; }
 _scope_err() {
 	_err "unknown scope '$1'"
-	_hint "Defined scopes: ${CFG_SCOPE_NAMES[*]}"
+	_hint "Defined scopes: ${!CFG_SCOPES[*]}"
 }
 _show_errors() {
 	local e
@@ -20,7 +20,7 @@ _show_errors() {
 }
 
 # Get multi-scope separator
-_get_sep() { get_setting multi-scope-separator ","; }
+_get_sep() { echo "${CFG_SETTINGS[multi_scope_separator]:-,}"; }
 
 # Check all scopes in a multi-scope string exist
 # Usage: _check_scopes_exist <scope_str>
@@ -32,7 +32,7 @@ _check_scopes_exist() {
 	for s in "${_scopes[@]}"; do
 		_trim s
 		[[ "$s" == "*" ]] && continue
-		scope_exists "$s" || {
+		[[ -v CFG_SCOPES["$s"] ]] || {
 			_scope_err "$s"
 			return 1
 		}
@@ -65,34 +65,10 @@ cmd_lint() {
 	local breaking="${BASH_REMATCH[4]}" description="${BASH_REMATCH[5]}"
 
 	# Validate type
-	local type_index=-1
-	for i in "${!TYPES[@]}"; do
-		[[ "${TYPES[$i]}" == "$type" ]] && {
-			type_index=$i
-			break
-		}
-	done
-
-	if [[ $type_index -lt 0 ]]; then
+	if [[ ! -v CFG_TYPES["$type"] ]]; then
 		_err "unknown type '$type'"
-		_hint "Allowed types: ${TYPES[*]}"
+		_hint "Allowed types: ${!CFG_TYPES[*]}"
 		return 1
-	fi
-
-	# Validate scope if present and scopes defined for this type
-	if [[ -n "$scope" && -n "${SCOPES[$type_index]}" ]]; then
-		local scope_valid=false allowed
-		for allowed in ${SCOPES[$type_index]}; do
-			[[ "$allowed" == "$scope" ]] && {
-				scope_valid=true
-				break
-			}
-		done
-		if [[ "$scope_valid" != true ]]; then
-			_err "invalid scope '$scope' for type '$type'"
-			_hint "Allowed scopes: ${SCOPES[$type_index]}"
-			return 1
-		fi
 	fi
 
 	# Validate description is not empty
@@ -133,25 +109,25 @@ validate_paths_if_needed() {
 	elif [[ "${STRICT-unset}" == "" ]]; then
 		strict_mode=false
 	else
-		strict_mode="$(get_setting strict false)"
+		strict_mode="${CFG_SETTINGS[strict]:-false}"
 	fi
 
 	# In strict mode with scope, validate scope exists
 	if [[ "$strict_mode" == "true" && -n "$scope" ]]; then
-		[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && {
+		[[ ${#CFG_SCOPES[@]} -eq 0 ]] && {
 			_err "scope '$scope' used but no scopes defined in config"
 			return 1
 		}
 		if is_multi_scope "$scope"; then
 			_check_scopes_exist "$scope" || return 1
-		elif [[ "$scope" != "*" ]] && ! scope_exists "$scope"; then
+		elif [[ "$scope" != "*" && ! -v CFG_SCOPES["$scope"] ]]; then
 			_scope_err "$scope"
 			return 1
 		fi
 	fi
 
 	# Early exit if no scopes defined or no files to validate
-	[[ ${#CFG_SCOPE_NAMES[@]} -eq 0 ]] && return 0
+	[[ ${#CFG_SCOPES[@]} -eq 0 ]] && return 0
 	local -a files=()
 	mapfile -t files < <(get_files_to_validate)
 	[[ ${#files[@]} -eq 0 ]] && return 0
@@ -173,7 +149,7 @@ validate_paths_if_needed() {
 
 	# Multi-scope validation
 	if is_multi_scope "$scope"; then
-		[[ "$(get_setting multi-scope false)" != "true" ]] && {
+		[[ "${CFG_SETTINGS[multi_scope]:-false}" != "true" ]] && {
 			_err "multi-scope not enabled in config"
 			_hint "Set multi-scope = true in [settings] to use multiple scopes"
 			return 1
@@ -188,7 +164,7 @@ validate_paths_if_needed() {
 	fi
 
 	# Single scope validation
-	scope_exists "$scope" || {
+	[[ -v CFG_SCOPES["$scope"] ]] || {
 		_scope_err "$scope"
 		return 1
 	}

--- a/scripts/cz/cmd_parse.sh
+++ b/scripts/cz/cmd_parse.sh
@@ -22,33 +22,32 @@ cmd_parse() {
 	echo
 
 	# Show settings
-	if [[ -n "${CFG_SETTINGS_strict:-}" || -n "${CFG_SETTINGS_multi_scope:-}" ]]; then
+	if [[ ${#CFG_SETTINGS[@]} -gt 0 ]]; then
 		echo "Settings:"
-		[[ -n "${CFG_SETTINGS_strict:-}" ]] && echo "  strict = ${CFG_SETTINGS_strict}"
-		[[ -n "${CFG_SETTINGS_multi_scope:-}" ]] && echo "  multi-scope = ${CFG_SETTINGS_multi_scope}"
-		[[ -n "${CFG_SETTINGS_multi_scope_separator:-}" ]] && echo "  multi-scope-separator = ${CFG_SETTINGS_multi_scope_separator}"
+		[[ -v CFG_SETTINGS[strict] ]] && echo "  strict = ${CFG_SETTINGS[strict]}"
+		[[ -v CFG_SETTINGS[multi_scope] ]] && echo "  multi-scope = ${CFG_SETTINGS[multi_scope]}"
+		[[ -v CFG_SETTINGS[multi_scope_separator] ]] && echo "  multi-scope-separator = ${CFG_SETTINGS[multi_scope_separator]}"
 		echo
 	fi
 
 	# Show scopes with patterns
-	if [[ ${#CFG_SCOPE_NAMES[@]} -gt 0 ]]; then
+	if [[ ${#CFG_SCOPES[@]} -gt 0 ]]; then
 		echo "Scopes:"
-		for scope in "${CFG_SCOPE_NAMES[@]}"; do
-			echo "  $scope = $(get_scope_patterns "$scope")"
+		local scope
+		for scope in "${!CFG_SCOPES[@]}"; do
+			echo "  $scope = ${CFG_SCOPES[$scope]}"
 		done
 		echo
 	fi
 
 	# Show types with descriptions
 	echo "Types:"
-	local max_type_len=0
-	for type in "${TYPES[@]}"; do
+	local max_type_len=0 type
+	for type in "${!CFG_TYPES[@]}"; do
 		((${#type} > max_type_len)) && max_type_len=${#type}
 	done
 
-	for i in "${!TYPES[@]}"; do
-		local type="${TYPES[$i]}"
-		local desc="${DESCRIPTIONS[$i]}"
-		printf "  %-${max_type_len}s  %s\n" "$type" "$desc"
+	for type in "${!CFG_TYPES[@]}"; do
+		printf "  %-${max_type_len}s  %s\n" "$type" "${CFG_TYPES[$type]}"
 	done
 }

--- a/scripts/cz/config.sh
+++ b/scripts/cz/config.sh
@@ -6,11 +6,11 @@
 . ./config_defaults.sh
 # @bundle source
 . ./config_parser.sh
-# Sets: TYPES, DESCRIPTIONS, SCOPES, GLOBAL_SCOPES, CONFIG_FILE
+# Sets associative arrays: CFG_TYPES, CFG_SCOPES, CFG_SETTINGS
 
 # Ensure config is loaded (idempotent)
 ensure_config() {
-	[[ -n "${TYPES+x}" && ${#TYPES[@]} -gt 0 ]] && return
+	[[ -n "${CFG_TYPES+x}" && ${#CFG_TYPES[@]} -gt 0 ]] && return
 	[[ -z "${CONFIG_FILE:-}" ]] && { find_config || true; }
 	load_config
 }
@@ -46,24 +46,24 @@ load_config() {
 
 		parse_config <"$CONFIG_FILE"
 
-		# If no types defined, fall back to defaults
-		if [[ ${#CFG_TYPE_NAMES[@]} -eq 0 ]]; then
+		# If no types defined, use default types but preserve settings/scopes
+		if [[ ${#CFG_TYPES[@]} -eq 0 ]]; then
 			[[ -z "${QUIET:-}" ]] && echo "cz: warning: no [types] in $CONFIG_FILE, using defaults" >&2
-			default_config
-			return
+			# Only set default types, preserve parsed settings and scopes
+			declare -gA CFG_TYPES=(
+				[feat]="A new feature"
+				[fix]="A bug fix"
+				[docs]="Documentation only changes"
+				[style]="Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+				[refactor]="A code change that neither fixes a bug nor adds a feature"
+				[perf]="A code change that improves performance"
+				[test]="Adding missing tests or correcting existing tests"
+				[build]="Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+				[ci]="Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+				[chore]="Other changes that don't modify src or test files"
+				[revert]="Reverts a previous commit"
+			)
 		fi
-
-		# Build TYPES/DESCRIPTIONS arrays from parsed config
-		TYPES=()
-		DESCRIPTIONS=()
-		SCOPES=()
-		GLOBAL_SCOPES=()
-		for type in "${CFG_TYPE_NAMES[@]}"; do
-			TYPES+=("$type")
-			local desc_var="CFG_TYPES_$type"
-			DESCRIPTIONS+=("${!desc_var:-}")
-			SCOPES+=("")
-		done
 	else
 		default_config
 	fi

--- a/scripts/cz/config_defaults.sh
+++ b/scripts/cz/config_defaults.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 # Format current config as .gitcommitizen file content (INI format)
-# Requires: TYPES, DESCRIPTIONS arrays to be set
+# Requires: CFG_TYPES associative array to be set
 format_config() {
 	echo "# Conventional Commits configuration"
 	echo "# See: gitcommitizen(5)"
@@ -16,57 +16,32 @@ format_config() {
 	echo "# example = src/example/**"
 	echo
 	echo "[types]"
-	for i in "${!TYPES[@]}"; do
-		echo "${TYPES[$i]} = ${DESCRIPTIONS[$i]}"
+	local type
+	for type in "${!CFG_TYPES[@]}"; do
+		echo "$type = ${CFG_TYPES[$type]}"
 	done
 }
 
 # Load default Conventional Commits (Angular) configuration
-# Sets arrays: TYPES, DESCRIPTIONS, GLOBAL_SCOPES, SCOPES, CFG_TYPE_NAMES, CFG_SCOPE_NAMES
+# Sets associative arrays: CFG_TYPES, CFG_SCOPES, CFG_SETTINGS
 default_config() {
-	# Initialize arrays with Angular/Conventional Commits standard types
-	export TYPES=(
-		"feat"
-		"fix"
-		"docs"
-		"style"
-		"refactor"
-		"perf"
-		"test"
-		"build"
-		"ci"
-		"chore"
-		"revert"
+	# Note: =() initialization required for set -u compatibility
+	unset CFG_TYPES CFG_SCOPES CFG_SETTINGS
+	# shellcheck disable=SC2034 # used by other modules
+	declare -gA CFG_SCOPES=() CFG_SETTINGS=()
+	declare -gA CFG_TYPES=(
+		[feat]="A new feature"
+		[fix]="A bug fix"
+		[docs]="Documentation only changes"
+		[style]="Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+		[refactor]="A code change that neither fixes a bug nor adds a feature"
+		[perf]="A code change that improves performance"
+		[test]="Adding missing tests or correcting existing tests"
+		[build]="Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+		[ci]="Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+		[chore]="Other changes that don't modify src or test files"
+		[revert]="Reverts a previous commit"
 	)
-
-	export DESCRIPTIONS=(
-		"A new feature"
-		"A bug fix"
-		"Documentation only changes"
-		"Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
-		"A code change that neither fixes a bug nor adds a feature"
-		"A code change that improves performance"
-		"Adding missing tests or correcting existing tests"
-		"Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
-		"Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
-		"Other changes that don't modify src or test files"
-		"Reverts a previous commit"
-	)
-
-	# No global scopes by default
-	export GLOBAL_SCOPES=()
-
-	# No type-specific scopes by default
-	export SCOPES=()
-	for _ in "${!TYPES[@]}"; do
-		SCOPES+=("")
-	done
-
-	# Set CFG_ arrays for compatibility with parse_config consumers
-	# shellcheck disable=SC2034 # used by config.sh consumers
-	CFG_TYPE_NAMES=("${TYPES[@]}")
-	# shellcheck disable=SC2034 # used by config.sh consumers
-	CFG_SCOPE_NAMES=()
 
 	return 0
 }

--- a/scripts/cz/config_parser.sh
+++ b/scripts/cz/config_parser.sh
@@ -1,16 +1,13 @@
-# shellcheck shell=bash
-
-# Get scope variable name (handles wildcard -> __wildcard__)
-_scope_var() { [[ "$1" == "*" ]] && echo "CFG_SCOPES___wildcard__" || echo "CFG_SCOPES_$1"; }
+# shellcheck shell=bash disable=SC2034
 
 # Parse .gitcommitizen configuration from stdin
-# Sets variables: CFG_SETTINGS_*, CFG_SCOPES_*, CFG_TYPES_*
-# Also sets arrays: CFG_SCOPE_NAMES, CFG_TYPE_NAMES
+# Sets associative arrays: CFG_SETTINGS, CFG_SCOPES, CFG_TYPES
+# Note: SC2034 disabled - arrays are used by other modules
 parse_config() {
-	# Clear previous state
-	unset "${!CFG_SETTINGS_@}" "${!CFG_SCOPES_@}" "${!CFG_TYPES_@}"
-	CFG_SCOPE_NAMES=()
-	CFG_TYPE_NAMES=()
+	# Clear previous state and declare associative arrays
+	# Note: =() initialization required for set -u compatibility
+	unset CFG_SETTINGS CFG_SCOPES CFG_TYPES
+	declare -gA CFG_SETTINGS=() CFG_SCOPES=() CFG_TYPES=()
 
 	[[ -t 0 ]] && return 0
 
@@ -38,57 +35,18 @@ parse_config() {
 			value="${value#"${value%%[![:space:]]*}"}"
 			value="${value%"${value##*[![:space:]]}"}"
 
-			# Normalize key (replace - with _)
-			local norm_key="${key//-/_}"
-
 			case "$section" in
 				settings)
-					declare -g "CFG_SETTINGS_$norm_key=$value"
+					# Normalize key (replace - with _)
+					CFG_SETTINGS["${key//-/_}"]="$value"
 					;;
 				scopes)
-					# Handle wildcard scope specially (bash can't have * in var names)
-					if [[ "$key" == "*" ]]; then
-						declare -g "CFG_SCOPES___wildcard__=$value"
-					else
-						declare -g "CFG_SCOPES_$key=$value"
-					fi
-					CFG_SCOPE_NAMES+=("$key")
+					CFG_SCOPES["$key"]="$value"
 					;;
 				types)
-					declare -g "CFG_TYPES_$key=$value"
-					CFG_TYPE_NAMES+=("$key")
+					CFG_TYPES["$key"]="$value"
 					;;
 			esac
 		fi
 	done
-}
-
-# Get setting value with default
-# Usage: get_setting <key> [default]
-get_setting() {
-	local key="${1//-/_}"
-	local default="${2:-}"
-	local var="CFG_SETTINGS_$key"
-	echo "${!var:-$default}"
-}
-
-# Check if scope exists
-scope_exists() {
-	local var
-	var="$(_scope_var "$1")"
-	[[ -n "${!var+x}" ]]
-}
-
-# Get scope patterns
-get_scope_patterns() {
-	local var
-	var="$(_scope_var "$1")"
-	echo "${!var:-}"
-}
-
-# Check if type exists
-# Usage: type_exists <name>
-type_exists() {
-	local var="CFG_TYPES_$1"
-	[[ -n "${!var+x}" ]]
 }

--- a/scripts/cz/path_validator.sh
+++ b/scripts/cz/path_validator.sh
@@ -57,7 +57,7 @@ file_matches_pattern() {
 # Usage: file_matches_scope <file> <scope>
 file_matches_scope() {
 	local file="$1" scope="$2" patterns pattern
-	patterns="$(get_scope_patterns "$scope")"
+	patterns="${CFG_SCOPES[$scope]:-}"
 	[[ -z "$patterns" ]] && return 1
 
 	IFS=',' read -ra pattern_arr <<<"$patterns"
@@ -71,7 +71,7 @@ file_matches_scope() {
 # Find which scope a file matches (skips wildcard)
 find_matching_scope() {
 	local file="$1" scope
-	for scope in "${CFG_SCOPE_NAMES[@]}"; do
+	for scope in "${!CFG_SCOPES[@]}"; do
 		[[ "$scope" == "*" ]] && continue
 		file_matches_scope "$file" "$scope" && {
 			echo "$scope"
@@ -102,7 +102,7 @@ validate_files_against_scopes() {
 	shift
 	local file scope matched
 	local IFS
-	IFS="$(get_setting multi-scope-separator ",")"
+	IFS="${CFG_SETTINGS[multi_scope_separator]:-,}"
 	VALIDATION_ERRORS=()
 
 	read -ra scopes_arr <<<"$scopes_str"


### PR DESCRIPTION
## Summary
- Replace parallel indexed arrays with Bash 4+ associative arrays for config
- Remove dead code (GLOBAL_SCOPES, per-type SCOPES, helper functions)
- Direct array access instead of helper functions throughout

## Changes
- `CFG_TYPES[type]` -> description (was: TYPES[], DESCRIPTIONS[], CFG_TYPE_NAMES[])
- `CFG_SCOPES[scope]` -> patterns (was: CFG_SCOPE_NAMES[], CFG_SCOPES_* vars)
- `CFG_SETTINGS[key]` -> value (was: CFG_SETTINGS_* vars)

## Removed
- `get_setting()`, `scope_exists()`, `get_scope_patterns()`, `type_exists()` helpers
- `GLOBAL_SCOPES` array (dead code)
- `SCOPES` per-type array (unused)