### PR TITLE
feat: add kcov coverage support for macOS

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,1 +1,2 @@
+--shell bash
 --execdir @specfile

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo "  build [NAME=x]         - Build all scripts or a specific one to dist/"
 	@echo "  install DESTDIR=x [NAME=y] - Install scripts to DESTDIR"
 	@echo "  clean                  - Remove generated files in dist/"
-	@echo "  test [NAME=x]          - Run tests (all, or specific script)"
+	@echo "  test [NAME=x]          - Run tests with coverage (all, or specific script)"
 	@echo "  lint [NAME=x]          - Run shellcheck and shfmt check"
 	@echo "  fmt [NAME=x]           - Format shell scripts with shfmt"
 	@echo "  new-script NAME=x      - Create a new script from templates"
@@ -132,24 +132,28 @@ clean:
 	@rm -rf $(DIST_DIR)/*
 	@echo "Done."
 
-# Test: all, specific script, or utils
+# Test: all, specific script, or utils (with coverage)
 test:
 ifdef NAME
 	@if [ "$(NAME)" = "utils" ]; then \
 		echo "Running tests for utils..."; \
-		shellspec --shell bash utils; \
+		shellspec utils; \
 	else \
 		if [ ! -d "$(SCRIPTS_DIR)/$(NAME)" ]; then \
 			echo "Error: script '$(NAME)' not found in $(SCRIPTS_DIR)/"; \
 			exit 1; \
 		fi; \
+		$(MAKE) --no-print-directory build NAME=$(NAME); \
 		echo "Running tests for $(NAME)..."; \
-		shellspec --shell bash --helperdir scripts --require spec_helper $(SCRIPTS_DIR)/$(NAME); \
+		shellspec --kcov --kcov-options="--include-pattern=$(DIST_DIR)/$(NAME)/bin" \
+			--helperdir scripts --require spec_helper $(SCRIPTS_DIR)/$(NAME); \
 	fi
 else
 	@echo "Running all tests..."
-	@shellspec --shell bash --helperdir scripts --require spec_helper scripts
-	@shellspec --shell bash utils
+	@$(MAKE) --no-print-directory build
+	@shellspec --kcov --kcov-options="--include-pattern=$(DIST_DIR)/" \
+		--helperdir scripts --require spec_helper scripts
+	@shellspec utils
 endif
 
 # Lint: all, specific script, or utils

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,22 @@
         "type": "github"
       }
     },
+    "kcov-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767509369,
+        "narHash": "sha256-13V6vnPXECccqwQ2sR0WUEuOSAQ4ieSng/vYDJ5hVJc=",
+        "owner": "SimonKagstrom",
+        "repo": "kcov",
+        "rev": "46094099f61bb7b53c94af73a1154f26da23bad3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SimonKagstrom",
+        "repo": "kcov",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767995494,
@@ -37,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "kcov-src": "kcov-src",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    kcov-src = {
+      url = "github:SimonKagstrom/kcov";
+      flake = false;
+    };
   };
 
   outputs =
@@ -11,6 +15,7 @@
       self,
       nixpkgs,
       flake-utils,
+      kcov-src,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -70,10 +75,51 @@
           jwt = import ./scripts/jwt { inherit mkScript; };
           theme = import ./scripts/theme { inherit mkScript; };
         };
+
+        # kcov built from source for macOS (nixpkgs kcov doesn't support Darwin)
+        kcov-darwin = pkgs.stdenv.mkDerivation {
+          pname = "kcov";
+          version = kcov-src.shortRev or "dev";
+          src = kcov-src;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            darwin.bootstrap_cmds
+            darwin.sigtool
+          ];
+
+          buildInputs = with pkgs; [
+            zlib
+            openssl
+            python3
+            curl
+            libdwarf
+          ];
+
+          cmakeFlags = [
+            "-G"
+            "Ninja"
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DDWARFUTILS_INCLUDE_DIR=${pkgs.libdwarf.dev}/include/libdwarf-2"
+            "-DDWARFUTILS_LIBRARY=${pkgs.libdwarf.lib}/lib/libdwarf.2.dylib"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Code coverage tool for compiled programs";
+            homepage = "https://github.com/SimonKagstrom/kcov";
+            license = licenses.gpl2Only;
+            platforms = platforms.darwin;
+          };
+        };
       in
       {
         packages = scripts // {
           # Individual scripts exposed via: nix build .#<name>
+
+          # kcov for macOS (nixpkgs doesn't support Darwin)
+          kcov = if pkgs.stdenv.isDarwin then kcov-darwin else pkgs.kcov;
 
           # Meta-package with all scripts and plugins
           default = pkgs.stdenv.mkDerivation {
@@ -103,6 +149,9 @@
         devShells.default = pkgs.mkShell {
           buildInputs =
             buildTools
+            ++ [
+              (if pkgs.stdenv.isDarwin then kcov-darwin else pkgs.kcov)
+            ]
             ++ (with pkgs; [
               zsh
               shellspec


### PR DESCRIPTION
Add kcov for code coverage on macOS (nixpkgs kcov doesn't support Darwin).

- Build kcov from source via flake input
- Add kcov to devShell
- Integrate coverage into `make test` target
- Add `--shell bash` to .shellspec for BASH_ENV compatibility