### PR TITLE
fix(jwt): use manual cleanup instead of trap for temp files

### DIFF
--- a/dist/jwt/bin/jwt
+++ b/dist/jwt/bin/jwt
@@ -488,25 +488,29 @@ verify_ecdsa() {
 # $1: PEM public key content
 verify_pss() {
 	local key=$1
-	local digest sig_file
+	local digest sig_file key_file result=0
 
 	check_algorithm_support "$JWT_ALG" || return $?
 	digest=$(get_openssl_digest) || return $?
 
-	# Create temp file for signature
+	# Create temp files for signature and key
+	# Note: manual cleanup instead of trap - kcov triggers RETURN trap prematurely
 	sig_file=$(mktemp)
-	# shellcheck disable=SC2064 # intentional: expand now for correct file
-	trap "rm -f '$sig_file'" RETURN
+	key_file=$(mktemp)
 
 	# Decode signature and write to temp file
 	base64url_decode "$JWT_SIG_B64" >"$sig_file"
+	printf '%s\n' "$key" >"$key_file"
 
-	# Verify with RSA-PSS padding using process substitution for key
+	# Verify with RSA-PSS padding
 	local signing_input="${JWT_HEADER_B64}.${JWT_PAYLOAD_B64}"
-	if ! printf '%s' "$signing_input" | openssl dgst -"$digest" -verify <(printf '%s\n' "$key") -signature "$sig_file" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 &>/dev/null; then
+	if ! printf '%s' "$signing_input" | openssl dgst -"$digest" -verify "$key_file" -signature "$sig_file" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 &>/dev/null; then
 		echo "jwt: error: signature verification failed" >&2
-		return 1
+		result=1
 	fi
+
+	rm -f "$sig_file" "$key_file"
+	return $result
 }
 
 # Verify EdDSA signature (Ed25519)
@@ -515,15 +519,15 @@ verify_pss() {
 # $1: PEM public key content
 verify_eddsa() {
 	local key=$1
-	local sig_file input_file
+	local sig_file input_file key_file result=0
 
 	check_algorithm_support "EdDSA" || return $?
 
-	# Create temp files for signature and input (pkeyutl needs files for -in and -sigfile)
+	# Create temp files for signature, input, and key
+	# Note: manual cleanup instead of trap - kcov triggers RETURN trap prematurely
 	sig_file=$(mktemp)
 	input_file=$(mktemp)
-	# shellcheck disable=SC2064 # intentional: expand now for correct files
-	trap "rm -f '$sig_file' '$input_file'" RETURN
+	key_file=$(mktemp)
 
 	# Decode signature and write to temp file
 	base64url_decode "$JWT_SIG_B64" >"$sig_file"
@@ -531,12 +535,16 @@ verify_eddsa() {
 	# Write signing input to temp file (Ed25519 needs -rawin with file input)
 	local signing_input="${JWT_HEADER_B64}.${JWT_PAYLOAD_B64}"
 	printf '%s' "$signing_input" >"$input_file"
+	printf '%s\n' "$key" >"$key_file"
 
-	# Verify with pkeyutl using process substitution for key
-	if ! openssl pkeyutl -verify -pubin -inkey <(printf '%s\n' "$key") -rawin -in "$input_file" -sigfile "$sig_file" &>/dev/null; then
+	# Verify with pkeyutl
+	if ! openssl pkeyutl -verify -pubin -inkey "$key_file" -rawin -in "$input_file" -sigfile "$sig_file" &>/dev/null; then
 		echo "jwt: error: signature verification failed" >&2
-		return 1
+		result=1
 	fi
+
+	rm -f "$sig_file" "$input_file" "$key_file"
+	return $result
 }
 
 # Main verification dispatcher

--- a/scripts/jwt/main_spec.sh
+++ b/scripts/jwt/main_spec.sh
@@ -224,21 +224,13 @@ Describe 'jwt'
 	# RSA-PSS VERIFICATION (OpenSSL 3.x)
 	#═══════════════════════════════════════════════════════════════
 	Describe 'RSA-PSS verification'
-		skip_if_old_openssl() {
-			local version
-			version=$(openssl version 2>/dev/null | grep -oE '[0-9]+' | head -1)
-			[[ "${version:-0}" -lt 3 ]]
-		}
-
 		It 'verifies PS256 with correct public key'
-			Skip if "OpenSSL < 3.x" skip_if_old_openssl
 			When run script "$BIN" -v "@$FIXTURES/ps256_public.pem" "$ps256_token"
 			The status should be success
 			The output should include '"sub":"1234567890"'
 		End
 
 		It 'rejects PS256 with wrong key'
-			Skip if "OpenSSL < 3.x" skip_if_old_openssl
 			When run script "$BIN" -v "@$FIXTURES/ed25519_public.pem" "$ps256_token"
 			The status should be failure
 			The stderr should include "verification failed"
@@ -249,21 +241,13 @@ Describe 'jwt'
 	# EdDSA VERIFICATION (OpenSSL 3.x)
 	#═══════════════════════════════════════════════════════════════
 	Describe 'EdDSA verification'
-		skip_if_old_openssl() {
-			local version
-			version=$(openssl version 2>/dev/null | grep -oE '[0-9]+' | head -1)
-			[[ "${version:-0}" -lt 3 ]]
-		}
-
 		It 'verifies EdDSA with correct public key'
-			Skip if "OpenSSL < 3.x" skip_if_old_openssl
 			When run script "$BIN" -v "@$FIXTURES/ed25519_public.pem" "$eddsa_token"
 			The status should be success
 			The output should include '"sub":"1234567890"'
 		End
 
 		It 'rejects EdDSA with wrong key'
-			Skip if "OpenSSL < 3.x" skip_if_old_openssl
 			When run script "$BIN" -v "@$FIXTURES/ps256_public.pem" "$eddsa_token"
 			The status should be failure
 			The stderr should include "verification failed"

--- a/scripts/jwt/verify.sh
+++ b/scripts/jwt/verify.sh
@@ -209,25 +209,29 @@ verify_ecdsa() {
 # $1: PEM public key content
 verify_pss() {
 	local key=$1
-	local digest sig_file
+	local digest sig_file key_file result=0
 
 	check_algorithm_support "$JWT_ALG" || return $?
 	digest=$(get_openssl_digest) || return $?
 
-	# Create temp file for signature
+	# Create temp files for signature and key
+	# Note: manual cleanup instead of trap - kcov triggers RETURN trap prematurely
 	sig_file=$(mktemp)
-	# shellcheck disable=SC2064 # intentional: expand now for correct file
-	trap "rm -f '$sig_file'" RETURN
+	key_file=$(mktemp)
 
 	# Decode signature and write to temp file
 	base64url_decode "$JWT_SIG_B64" >"$sig_file"
+	printf '%s\n' "$key" >"$key_file"
 
-	# Verify with RSA-PSS padding using process substitution for key
+	# Verify with RSA-PSS padding
 	local signing_input="${JWT_HEADER_B64}.${JWT_PAYLOAD_B64}"
-	if ! printf '%s' "$signing_input" | openssl dgst -"$digest" -verify <(printf '%s\n' "$key") -signature "$sig_file" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 &>/dev/null; then
+	if ! printf '%s' "$signing_input" | openssl dgst -"$digest" -verify "$key_file" -signature "$sig_file" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 &>/dev/null; then
 		echo "jwt: error: signature verification failed" >&2
-		return 1
+		result=1
 	fi
+
+	rm -f "$sig_file" "$key_file"
+	return $result
 }
 
 # Verify EdDSA signature (Ed25519)
@@ -236,15 +240,15 @@ verify_pss() {
 # $1: PEM public key content
 verify_eddsa() {
 	local key=$1
-	local sig_file input_file
+	local sig_file input_file key_file result=0
 
 	check_algorithm_support "EdDSA" || return $?
 
-	# Create temp files for signature and input (pkeyutl needs files for -in and -sigfile)
+	# Create temp files for signature, input, and key
+	# Note: manual cleanup instead of trap - kcov triggers RETURN trap prematurely
 	sig_file=$(mktemp)
 	input_file=$(mktemp)
-	# shellcheck disable=SC2064 # intentional: expand now for correct files
-	trap "rm -f '$sig_file' '$input_file'" RETURN
+	key_file=$(mktemp)
 
 	# Decode signature and write to temp file
 	base64url_decode "$JWT_SIG_B64" >"$sig_file"
@@ -252,12 +256,16 @@ verify_eddsa() {
 	# Write signing input to temp file (Ed25519 needs -rawin with file input)
 	local signing_input="${JWT_HEADER_B64}.${JWT_PAYLOAD_B64}"
 	printf '%s' "$signing_input" >"$input_file"
+	printf '%s\n' "$key" >"$key_file"
 
-	# Verify with pkeyutl using process substitution for key
-	if ! openssl pkeyutl -verify -pubin -inkey <(printf '%s\n' "$key") -rawin -in "$input_file" -sigfile "$sig_file" &>/dev/null; then
+	# Verify with pkeyutl
+	if ! openssl pkeyutl -verify -pubin -inkey "$key_file" -rawin -in "$input_file" -sigfile "$sig_file" &>/dev/null; then
 		echo "jwt: error: signature verification failed" >&2
-		return 1
+		result=1
 	fi
+
+	rm -f "$sig_file" "$input_file" "$key_file"
+	return $result
 }
 
 # Main verification dispatcher


### PR DESCRIPTION
Replace `trap ... RETURN` with explicit cleanup in verify_pss and verify_eddsa functions.

kcov instrumentation triggers RETURN traps prematurely, causing temp files to be deleted before openssl can read them. This resulted in PS256 and EdDSA verification tests failing when running with kcov coverage.

Changes:
- Use temp file for key instead of process substitution
- Replace trap-based cleanup with explicit `rm -f` after verification
- Remove redundant skip_if_old_openssl checks (CI always uses OpenSSL 3.x via nix)