### PR TITLE
ci: add PR title validation with cz

### DIFF
--- a/.gitcommitizen
+++ b/.gitcommitizen
@@ -1,0 +1,26 @@
+# Conventional Commits configuration
+# See: https://www.conventionalcommits.org/
+
+[settings]
+# Allow multiple scopes (e.g., feat(jwt,cz): ...)
+multi-scope = true
+
+[types]
+feat = A new feature
+fix = A bug fix
+docs = Documentation only changes
+style = Changes that do not affect the meaning of the code
+refactor = A code change that neither fixes a bug nor adds a feature
+perf = A code change that improves performance
+test = Adding missing tests or correcting existing tests
+build = Changes that affect the build system or external dependencies
+ci = Changes to CI configuration files and scripts
+chore = Other changes that don't modify src or test files
+revert = Reverts a previous commit
+
+[scopes]
+# Script scopes - use when changes target a specific script
+jwt = scripts/jwt/**, dist/jwt/**
+cz = scripts/cz/**, dist/cz/**
+dotenv = scripts/dotenv/**, dist/dotenv/**
+theme = scripts/theme/**, dist/theme/**

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,27 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+
+      - name: Validate PR title
+        run: |
+          FILES=$(gh pr view "$PR_NUMBER" --json files -q '.files[].path' | tr '\n' ' ')
+
+          if ! OUTPUT=$(echo "$PR_TITLE" | nix shell .#cz --command cz lint --files "$FILES" 2>&1); then
+            echo "::error title=Invalid PR Title::$OUTPUT"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 !scriptorium.plugin.zsh
 !release-please-config.json
 !.release-please-manifest.json
+!.gitcommitizen
 
 # Track subdirectories (each has its own .gitignore)
 !*/


### PR DESCRIPTION
Add PR title validation using `cz lint` to ensure PR titles follow conventional commits format.

## How it works

1. On PR open/edit/sync, gets list of changed files
2. Validates PR title with `nix shell .#cz --command cz lint --files "<changed files>"`
3. On failure: posts GitHub Actions error annotation with details

## Config scopes

| Scope | Files |
|-------|-------|
| jwt | `scripts/jwt/**`, `dist/jwt/**` |
| cz | `scripts/cz/**`, `dist/cz/**` |
| dotenv | `scripts/dotenv/**`, `dist/dotenv/**` |
| theme | `scripts/theme/**`, `dist/theme/**` |