### PR TITLE
fix(nix): add patchShebangs to mkScript for proper execution

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
 
             installPhase = ''
               make install NAME=${name} DESTDIR=$out
+              patchShebangs $out/bin
             '';
 
             meta = with pkgs.lib; {


### PR DESCRIPTION
Add `patchShebangs $out/bin` to the mkScript installPhase.

Without this, scripts using `#!/usr/bin/env bash` fail with "Exec format error" when run via `nix run` because `/usr/bin/env` may not exist in the Nix sandbox.

`patchShebangs` rewrites shebangs to Nix store paths (e.g., `#!/nix/store/...-bash-5.x/bin/bash`), making scripts self-contained and executable in pure Nix environments.

This enables using `nix run .#cz` instead of `nix develop --command` workarounds.