### PR TITLE
ci(scripts): add concurrency to prevent coverage gist race condition

### DIFF
--- a/.github/workflows/scripts-ci.yaml
+++ b/.github/workflows/scripts-ci.yaml
@@ -12,6 +12,11 @@ on:
     paths:
       - "scripts/**"
   workflow_dispatch:
+
+# Serialize gist updates to prevent race conditions when multiple PRs merge
+concurrency:
+  group: scripts-ci-coverage-${{ github.ref }}
+  cancel-in-progress: false
     inputs:
       scripts:
         description: 'Scripts to run CI for (comma-separated, e.g., "cz,jwt" or "all")'


### PR DESCRIPTION
## Summary
- Add concurrency group to scripts-ci workflow to serialize coverage gist updates
- Prevents race condition when multiple PRs merge close together

## Problem
When multiple PRs merge around the same time:
1. Both workflow runs fetch the same baseline from the gist
2. Each computes merged = baseline + their_new_coverage
3. The last one to finish overwrites the first's changes

## Solution
Add `concurrency` group with `cancel-in-progress: false` to ensure workflow runs complete sequentially, preventing coverage data loss.