### PR TITLE
feat(theme): make detection pluggable via user-provided detectors

### DIFF
--- a/dist/theme/bin/theme
+++ b/dist/theme/bin/theme
@@ -132,87 +132,6 @@ GETOPTIONSHERE
 
 # --- begin: scripts/theme/detect.sh ---
 
-_theme_detect_macos() {
-	local result
-	if ! command -v defaults >/dev/null 2>&1; then
-		return 1
-	fi
-
-	if result=$(defaults read -g AppleInterfaceStyle 2>/dev/null); then
-		case "${result,,}" in
-			dark) THEME_APPEARANCE=dark ;;
-			*) THEME_APPEARANCE=light ;;
-		esac
-	else
-		THEME_APPEARANCE=light
-	fi
-	return 0
-}
-
-_theme_detect_linux() {
-	local result
-	local desktop="${XDG_CURRENT_DESKTOP:-}"
-
-	case "$desktop" in
-		GNOME | Unity | ubuntu:GNOME | gnome)
-			if command -v gsettings >/dev/null 2>&1; then
-				result=$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null) || return 1
-				case "$result" in
-					*prefer-dark* | *dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-		KDE | plasma)
-			if command -v kreadconfig5 >/dev/null 2>&1; then
-				result=$(kreadconfig5 --file kdeglobals --group General --key ColorScheme 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			elif command -v kreadconfig >/dev/null 2>&1; then
-				result=$(kreadconfig --file kdeglobals --group General --key ColorScheme 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-		XFCE | xfce)
-			if command -v xfconf-query >/dev/null 2>&1; then
-				result=$(xfconf-query -c xsettings -p /Net/ThemeName 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-	esac
-
-	return 1
-}
-
-_theme_detect_windows() {
-	local result
-
-	if ! command -v reg.exe >/dev/null 2>&1; then
-		return 1
-	fi
-
-	result=$(reg.exe query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize" /v AppsUseLightTheme 2>/dev/null) || return 1
-
-	if [[ "$result" == *"0x0"* ]]; then
-		THEME_APPEARANCE=dark
-	else
-		THEME_APPEARANCE=light
-	fi
-	return 0
-}
-
 theme_detect() {
 	local override="${1:-}"
 
@@ -235,32 +154,14 @@ theme_detect() {
 		esac
 	fi
 
-	case "$(uname -s)" in
-		Darwin)
-			if _theme_detect_macos; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-		Linux)
-			if [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
-				if _theme_detect_windows; then
-					THEME_SOURCE=detected
-					return 0
-				fi
-			fi
-			if _theme_detect_linux; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-		CYGWIN* | MINGW* | MSYS*)
-			if _theme_detect_windows; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-	esac
+	theme_discover_detectors
+	local detector
+	for detector in "${THEME_DETECTORS[@]}"; do
+		if "$detector"; then
+			THEME_SOURCE=detected
+			return 0
+		fi
+	done
 
 	if [[ -n "${THEME:-}" ]]; then
 		case "${THEME,,}" in
@@ -300,6 +201,21 @@ theme_discover_provider() {
 	return 1
 }
 
+theme_discover_detectors() {
+	THEME_DETECTORS=()
+
+	local detectors
+	detectors=$(declare -F | awk '{print $3}' | grep '^theme_detector_' | sort) || true
+
+	if [[ -n "$detectors" ]]; then
+		while IFS= read -r detector; do
+			THEME_DETECTORS+=("$detector")
+		done <<<"$detectors"
+	fi
+
+	return 0
+}
+
 theme_discover_handlers() {
 	THEME_HANDLERS=()
 
@@ -335,6 +251,8 @@ theme_source_handlers_dir() {
 theme_source_config() {
 	local config_dir="${1:-$THEME_CONFIG_DIR}"
 
+	theme_source_handlers_dir "$config_dir/detectors.d"
+
 	if [[ -f "$config_dir/config.sh" ]]; then
 		source "$config_dir/config.sh"
 	fi
@@ -349,9 +267,21 @@ theme_source_config() {
 }
 
 theme_list() {
+	theme_discover_detectors
 	theme_discover_provider || true
 	theme_discover_handlers
 
+	echo "Detectors:"
+	if [[ ${#THEME_DETECTORS[@]} -gt 0 ]]; then
+		local d
+		for d in "${THEME_DETECTORS[@]}"; do
+			echo "  $d"
+		done
+	else
+		echo "  (none found)"
+	fi
+
+	echo ""
 	echo "Provider:"
 	if [[ -n "$THEME_PROVIDER" ]]; then
 		echo "  $THEME_PROVIDER"
@@ -441,6 +371,7 @@ eval "set -- $REST"
 THEME_QUIET="${QUIET:-}"
 
 if [[ "${DETECT:-}" == "1" ]]; then
+	theme_source_config
 	theme_detect "${1:-}"
 	printf '%s\n' "$THEME_APPEARANCE"
 	exit 0

--- a/dist/theme/man/man1/theme.1
+++ b/dist/theme/man/man1/theme.1
@@ -35,7 +35,7 @@ theme \- extensible theme orchestrator for shell environments
 .SH "DESCRIPTION"
 .sp
 \fBtheme\fP detects the system appearance (dark or light mode) and orchestrates
-theme configuration across multiple tools via an extensible provider/handler
+theme configuration across multiple tools via an extensible detector/provider/handler
 system.
 .sp
 The command performs three steps:
@@ -48,8 +48,8 @@ The command performs three steps:
 .  sp -1
 .  IP " 1." 4.2
 .\}
-\fBDetection\fP \- Determines system appearance (dark/light) using OS\-native
-methods
+\fBDetection\fP \- Determines system appearance (dark/light) using user\-provided
+detector functions
 .RE
 .sp
 .RS 4
@@ -76,8 +76,8 @@ to theme variables (e.g., THEME_VARIANT, THEME_ACCENT)
 individual tools using the exported theme variables
 .RE
 .sp
-Providers and handlers are auto\-discovered by function name prefix or loaded
-from configuration files.
+Detectors, providers, and handlers are auto\-discovered by function name prefix
+or loaded from configuration files.
 .SH "OPTIONS"
 .sp
 \fB\-d\fP, \fB\-\-detect\fP
@@ -88,7 +88,7 @@ the provider or handlers.
 .sp
 \fB\-l\fP, \fB\-\-list\fP
 .RS 4
-List the discovered provider and all registered handlers.
+List the discovered detectors, provider, and all registered handlers.
 .RE
 .sp
 \fB\-q\fP, \fB\-\-quiet\fP
@@ -112,39 +112,189 @@ Show version information and exit.
 Override the detected appearance. When specified, detection is skipped and
 this value is passed directly to the provider.
 .RE
-.SH "DETECTION"
+.SH "DETECTORS"
 .sp
-\fBtheme\fP uses OS\-native methods to detect appearance:
+Detectors are user\-provided shell functions that detect the system appearance.
+This allows users to implement detection for their specific system rather than
+relying on hardcoded methods.
+.SS "Detector Contract"
+.sp
+Detectors must:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+Be named with prefix \f(CRtheme_detector_\fP (e.g., \f(CRtheme_detector_macos\fP)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+Return 1 if detection doesn\(cqt apply (wrong OS, missing tools)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+Return 0 and set \f(CRTHEME_APPEARANCE=dark\fP or \f(CRTHEME_APPEARANCE=light\fP on success
+.RE
+.SS "Detector Discovery"
+.sp
+Detectors are discovered from:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 1." 4.2
+.\}
+Functions matching \f(CRtheme_detector_*\fP in current shell
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 2." 4.2
+.\}
+Functions defined in scripts under \f(CR~/.config/theme/detectors.d/*.sh\fP
+.RE
+.sp
+Detectors are tried in alphabetical order. The first one that returns 0 wins.
+.SS "Detection Fallback"
+.sp
+If no detector succeeds:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 1." 4.2
+.\}
+Uses \f(CRTHEME\fP environment variable if set to "dark" or "light"
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 2." 4.2
+.\}
+Otherwise defaults to "light"
+.RE
+.SS "Example Detectors"
 .sp
 \fBmacOS\fP
 .RS 4
-Reads \f(CRAppleInterfaceStyle\fP via \f(CRdefaults read \-g AppleInterfaceStyle\fP.
-Returns "dark" if set to "Dark", otherwise "light".
+.sp
+.if n .RS 4
+.nf
+.fam C
+theme_detector_macos() {
+  [[ "$(uname \-s)" == "Darwin" ]] || return 1
+  command \-v defaults >/dev/null || return 1
+
+  if defaults read \-g AppleInterfaceStyle 2>/dev/null | grep \-qi dark; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
+.fam
+.fi
+.if n .RE
 .RE
 .sp
-\fBLinux (GNOME/Unity)\fP
+\fBGNOME\fP
 .RS 4
-Queries \f(CRorg.gnome.desktop.interface color\-scheme\fP via \f(CRgsettings\fP.
+.sp
+.if n .RS 4
+.nf
+.fam C
+theme_detector_gnome() {
+  [[ "${XDG_CURRENT_DESKTOP:\-}" == *GNOME* ]] || return 1
+  command \-v gsettings >/dev/null || return 1
+
+  local scheme
+  scheme=$(gsettings get org.gnome.desktop.interface color\-scheme 2>/dev/null) || return 1
+
+  case "$scheme" in
+    *dark*) THEME_APPEARANCE=dark ;;
+    *)\&      THEME_APPEARANCE=light ;;
+  esac
+}
+.fam
+.fi
+.if n .RE
 .RE
 .sp
-\fBLinux (KDE Plasma)\fP
+\fBKDE Plasma\fP
 .RS 4
-Reads \f(CRColorScheme\fP from \f(CRkdeglobals\fP via \f(CRkreadconfig5\fP.
+.sp
+.if n .RS 4
+.nf
+.fam C
+theme_detector_kde() {
+  command \-v kreadconfig5 >/dev/null || return 1
+
+  local scheme
+  scheme=$(kreadconfig5 \-\-file kdeglobals \-\-group General \-\-key ColorScheme 2>/dev/null) || return 1
+
+  case "${scheme,,}" in
+    *dark*) THEME_APPEARANCE=dark ;;
+    *)\&      THEME_APPEARANCE=light ;;
+  esac
+}
+.fam
+.fi
+.if n .RE
 .RE
 .sp
-\fBLinux (XFCE)\fP
+\fBWindows (WSL)\fP
 .RS 4
-Queries \f(CR/Net/ThemeName\fP via \f(CRxfconf\-query\fP.
-.RE
 .sp
-\fBWindows (WSL/Cygwin)\fP
-.RS 4
-Queries \f(CRAppsUseLightTheme\fP from Windows registry via \f(CRreg.exe\fP.
-.RE
-.sp
-\fBFallback\fP
-.RS 4
-Uses \f(CRTHEME\fP environment variable if set, otherwise defaults to "light".
+.if n .RS 4
+.nf
+.fam C
+theme_detector_wsl() {
+  [[ \-n "${WSL_DISTRO_NAME:\-}" ]] || return 1
+  command \-v reg.exe >/dev/null || return 1
+
+  local result
+  result=$(reg.exe query "HKCU\(rs\(rsSoftware\(rs\(rsMicrosoft\(rs\(rsWindows\(rs\(rsCurrentVersion\(rs\(rsThemes\(rs\(rsPersonalize" /v AppsUseLightTheme 2>/dev/null) || return 1
+
+  if [[ "$result" == *"0x0"* ]]; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
+.fam
+.fi
+.if n .RE
 .RE
 .SH "PROVIDERS"
 .sp
@@ -346,8 +496,14 @@ theme_handler_bottom() {
 .sp
 \fB~/.config/theme/config.sh\fP
 .RS 4
-User configuration file. Sourced before provider/handler discovery.
-Can be used to set default variables or configure behavior.
+User configuration file. Sourced after detectors but before provider/handler
+discovery. Can be used to set default variables or configure behavior.
+.RE
+.sp
+\fB~/.config/theme/detectors.d/\fP.sh*
+.RS 4
+Detector scripts. All \f(CR.sh\fP files in this directory are sourced first.
+Define \f(CRtheme_detector_*\fP functions to detect system appearance.
 .RE
 .sp
 \fB~/.config/theme/provider.sh\fP
@@ -453,6 +609,16 @@ Add to shell configuration for automatic theming on startup:
 .fam C
 # ~/.bashrc or ~/.zshrc
 source /path/to/theme.sh
+
+# Define detector (required \- detection is user\-provided)
+theme_detector_macos() {
+  [[ "$(uname \-s)" == "Darwin" ]] || return 1
+  if defaults read \-g AppleInterfaceStyle 2>/dev/null | grep \-qi dark; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
 
 # Define provider
 theme_provider_catppuccin() {

--- a/scripts/theme/detect.sh
+++ b/scripts/theme/detect.sh
@@ -1,96 +1,6 @@
 #!/usr/bin/env bash
-# theme detection - detects system appearance (dark/light)
+# theme detection - discovers and runs user-provided detector functions
 # shellcheck disable=SC2034 # THEME_APPEARANCE and THEME_SOURCE are used externally
-
-# Detect macOS appearance via defaults command
-# Sets THEME_APPEARANCE on success
-_theme_detect_macos() {
-	local result
-	if ! command -v defaults >/dev/null 2>&1; then
-		return 1
-	fi
-
-	if result=$(defaults read -g AppleInterfaceStyle 2>/dev/null); then
-		# AppleInterfaceStyle is set - check if Dark
-		case "${result,,}" in
-			dark) THEME_APPEARANCE=dark ;;
-			*) THEME_APPEARANCE=light ;;
-		esac
-	else
-		# AppleInterfaceStyle not set means light mode
-		THEME_APPEARANCE=light
-	fi
-	return 0
-}
-
-# Detect Linux appearance via desktop environment settings
-# Sets THEME_APPEARANCE on success
-_theme_detect_linux() {
-	local result
-	local desktop="${XDG_CURRENT_DESKTOP:-}"
-
-	case "$desktop" in
-		GNOME | Unity | ubuntu:GNOME | gnome)
-			if command -v gsettings >/dev/null 2>&1; then
-				result=$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null) || return 1
-				case "$result" in
-					*prefer-dark* | *dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-		KDE | plasma)
-			if command -v kreadconfig5 >/dev/null 2>&1; then
-				result=$(kreadconfig5 --file kdeglobals --group General --key ColorScheme 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			elif command -v kreadconfig >/dev/null 2>&1; then
-				result=$(kreadconfig --file kdeglobals --group General --key ColorScheme 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-		XFCE | xfce)
-			if command -v xfconf-query >/dev/null 2>&1; then
-				result=$(xfconf-query -c xsettings -p /Net/ThemeName 2>/dev/null) || return 1
-				case "${result,,}" in
-					*dark*) THEME_APPEARANCE=dark ;;
-					*) THEME_APPEARANCE=light ;;
-				esac
-				return 0
-			fi
-			;;
-	esac
-
-	return 1
-}
-
-# Detect Windows appearance via registry (for WSL/Cygwin)
-# Sets THEME_APPEARANCE on success
-_theme_detect_windows() {
-	local result
-
-	# Check if we're in WSL or have reg.exe
-	if ! command -v reg.exe >/dev/null 2>&1; then
-		return 1
-	fi
-
-	result=$(reg.exe query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize" /v AppsUseLightTheme 2>/dev/null) || return 1
-
-	if [[ "$result" == *"0x0"* ]]; then
-		THEME_APPEARANCE=dark
-	else
-		THEME_APPEARANCE=light
-	fi
-	return 0
-}
 
 # Main detection function
 # Usage: theme_detect [override]
@@ -98,7 +8,7 @@ _theme_detect_windows() {
 theme_detect() {
 	local override="${1:-}"
 
-	# Handle override argument
+	# Handle explicit override
 	if [[ -n "$override" ]]; then
 		case "${override,,}" in
 			dark)
@@ -118,34 +28,15 @@ theme_detect() {
 		esac
 	fi
 
-	# Try OS-specific detection based on platform
-	case "$(uname -s)" in
-		Darwin)
-			if _theme_detect_macos; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-		Linux)
-			# Check if WSL first
-			if [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
-				if _theme_detect_windows; then
-					THEME_SOURCE=detected
-					return 0
-				fi
-			fi
-			if _theme_detect_linux; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-		CYGWIN* | MINGW* | MSYS*)
-			if _theme_detect_windows; then
-				THEME_SOURCE=detected
-				return 0
-			fi
-			;;
-	esac
+	# Try each detector in alphabetical order
+	theme_discover_detectors
+	local detector
+	for detector in "${THEME_DETECTORS[@]}"; do
+		if "$detector"; then
+			THEME_SOURCE=detected
+			return 0
+		fi
+	done
 
 	# Fall back to THEME environment variable
 	if [[ -n "${THEME:-}" ]]; then

--- a/scripts/theme/discover.sh
+++ b/scripts/theme/discover.sh
@@ -22,6 +22,25 @@ theme_discover_provider() {
 	return 1
 }
 
+# Discover detector functions by prefix
+# Sets THEME_DETECTORS array with all discovered detector function names
+theme_discover_detectors() {
+	THEME_DETECTORS=()
+
+	# Find functions matching theme_detector_* prefix, sorted alphabetically
+	# grep returns 1 when no matches, so use || true to handle empty results
+	local detectors
+	detectors=$(declare -F | awk '{print $3}' | grep '^theme_detector_' | sort) || true
+
+	if [[ -n "$detectors" ]]; then
+		while IFS= read -r detector; do
+			THEME_DETECTORS+=("$detector")
+		done <<<"$detectors"
+	fi
+
+	return 0
+}
+
 # Discover handler functions by prefix
 # Sets THEME_HANDLERS array with all discovered handler function names
 theme_discover_handlers() {
@@ -64,9 +83,12 @@ theme_source_handlers_dir() {
 }
 
 # Source user configuration files
-# Sources: config.sh, provider.sh, handlers.d/*.sh
+# Sources: detectors.d/*.sh, config.sh, provider.sh, handlers.d/*.sh
 theme_source_config() {
 	local config_dir="${1:-$THEME_CONFIG_DIR}"
+
+	# Source detectors first (needed before detection)
+	theme_source_handlers_dir "$config_dir/detectors.d"
 
 	# Source user config if exists
 	if [[ -f "$config_dir/config.sh" ]]; then
@@ -86,11 +108,23 @@ theme_source_config() {
 	return 0
 }
 
-# List discovered provider and handlers
+# List discovered detectors, provider, and handlers
 theme_list() {
+	theme_discover_detectors
 	theme_discover_provider || true
 	theme_discover_handlers
 
+	echo "Detectors:"
+	if [[ ${#THEME_DETECTORS[@]} -gt 0 ]]; then
+		local d
+		for d in "${THEME_DETECTORS[@]}"; do
+			echo "  $d"
+		done
+	else
+		echo "  (none found)"
+	fi
+
+	echo ""
 	echo "Provider:"
 	if [[ -n "$THEME_PROVIDER" ]]; then
 		echo "  $THEME_PROVIDER"

--- a/scripts/theme/docs/theme.adoc
+++ b/scripts/theme/docs/theme.adoc
@@ -18,20 +18,20 @@ theme - extensible theme orchestrator for shell environments
 == DESCRIPTION
 
 *theme* detects the system appearance (dark or light mode) and orchestrates
-theme configuration across multiple tools via an extensible provider/handler
+theme configuration across multiple tools via an extensible detector/provider/handler
 system.
 
 The command performs three steps:
 
-1. *Detection* - Determines system appearance (dark/light) using OS-native
-   methods
+1. *Detection* - Determines system appearance (dark/light) using user-provided
+   detector functions
 2. *Provider* - Calls a user-registered provider function that maps appearance
    to theme variables (e.g., THEME_VARIANT, THEME_ACCENT)
 3. *Handlers* - Calls all registered handler functions that configure
    individual tools using the exported theme variables
 
-Providers and handlers are auto-discovered by function name prefix or loaded
-from configuration files.
+Detectors, providers, and handlers are auto-discovered by function name prefix
+or loaded from configuration files.
 
 == OPTIONS
 
@@ -40,7 +40,7 @@ from configuration files.
   the provider or handlers.
 
 *-l*, *--list*::
-  List the discovered provider and all registered handlers.
+  List the discovered detectors, provider, and all registered handlers.
 
 *-q*, *--quiet*::
   Suppress warning messages.
@@ -57,28 +57,107 @@ from configuration files.
   Override the detected appearance. When specified, detection is skipped and
   this value is passed directly to the provider.
 
-== DETECTION
+== DETECTORS
 
-*theme* uses OS-native methods to detect appearance:
+Detectors are user-provided shell functions that detect the system appearance.
+This allows users to implement detection for their specific system rather than
+relying on hardcoded methods.
+
+=== Detector Contract
+
+Detectors must:
+
+* Be named with prefix `theme_detector_` (e.g., `theme_detector_macos`)
+* Return 1 if detection doesn't apply (wrong OS, missing tools)
+* Return 0 and set `THEME_APPEARANCE=dark` or `THEME_APPEARANCE=light` on success
+
+=== Detector Discovery
+
+Detectors are discovered from:
+
+1. Functions matching `theme_detector_*` in current shell
+2. Functions defined in scripts under `~/.config/theme/detectors.d/*.sh`
+
+Detectors are tried in alphabetical order. The first one that returns 0 wins.
+
+=== Detection Fallback
+
+If no detector succeeds:
+
+1. Uses `THEME` environment variable if set to "dark" or "light"
+2. Otherwise defaults to "light"
+
+=== Example Detectors
 
 *macOS*::
-  Reads `AppleInterfaceStyle` via `defaults read -g AppleInterfaceStyle`.
-  Returns "dark" if set to "Dark", otherwise "light".
++
+[source,bash]
+----
+theme_detector_macos() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 1
+  command -v defaults >/dev/null || return 1
 
-*Linux (GNOME/Unity)*::
-  Queries `org.gnome.desktop.interface color-scheme` via `gsettings`.
+  if defaults read -g AppleInterfaceStyle 2>/dev/null | grep -qi dark; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
+----
 
-*Linux (KDE Plasma)*::
-  Reads `ColorScheme` from `kdeglobals` via `kreadconfig5`.
+*GNOME*::
++
+[source,bash]
+----
+theme_detector_gnome() {
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] || return 1
+  command -v gsettings >/dev/null || return 1
 
-*Linux (XFCE)*::
-  Queries `/Net/ThemeName` via `xfconf-query`.
+  local scheme
+  scheme=$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null) || return 1
 
-*Windows (WSL/Cygwin)*::
-  Queries `AppsUseLightTheme` from Windows registry via `reg.exe`.
+  case "$scheme" in
+    *dark*) THEME_APPEARANCE=dark ;;
+    *)      THEME_APPEARANCE=light ;;
+  esac
+}
+----
 
-*Fallback*::
-  Uses `THEME` environment variable if set, otherwise defaults to "light".
+*KDE Plasma*::
++
+[source,bash]
+----
+theme_detector_kde() {
+  command -v kreadconfig5 >/dev/null || return 1
+
+  local scheme
+  scheme=$(kreadconfig5 --file kdeglobals --group General --key ColorScheme 2>/dev/null) || return 1
+
+  case "${scheme,,}" in
+    *dark*) THEME_APPEARANCE=dark ;;
+    *)      THEME_APPEARANCE=light ;;
+  esac
+}
+----
+
+*Windows (WSL)*::
++
+[source,bash]
+----
+theme_detector_wsl() {
+  [[ -n "${WSL_DISTRO_NAME:-}" ]] || return 1
+  command -v reg.exe >/dev/null || return 1
+
+  local result
+  result=$(reg.exe query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize" /v AppsUseLightTheme 2>/dev/null) || return 1
+
+  if [[ "$result" == *"0x0"* ]]; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
+----
 
 == PROVIDERS
 
@@ -181,8 +260,12 @@ theme_handler_bottom() {
 == FILES
 
 *~/.config/theme/config.sh*::
-  User configuration file. Sourced before provider/handler discovery.
-  Can be used to set default variables or configure behavior.
+  User configuration file. Sourced after detectors but before provider/handler
+  discovery. Can be used to set default variables or configure behavior.
+
+*~/.config/theme/detectors.d/*.sh*::
+  Detector scripts. All `.sh` files in this directory are sourced first.
+  Define `theme_detector_*` functions to detect system appearance.
 
 *~/.config/theme/provider.sh*::
   Custom provider definition. Sourced during provider discovery.
@@ -242,6 +325,16 @@ Add to shell configuration for automatic theming on startup:
 ----
 # ~/.bashrc or ~/.zshrc
 source /path/to/theme.sh
+
+# Define detector (required - detection is user-provided)
+theme_detector_macos() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 1
+  if defaults read -g AppleInterfaceStyle 2>/dev/null | grep -qi dark; then
+    THEME_APPEARANCE=dark
+  else
+    THEME_APPEARANCE=light
+  fi
+}
 
 # Define provider
 theme_provider_catppuccin() {

--- a/scripts/theme/main.sh
+++ b/scripts/theme/main.sh
@@ -27,6 +27,7 @@ THEME_QUIET="${QUIET:-}"
 
 # Handle flags
 if [[ "${DETECT:-}" == "1" ]]; then
+	theme_source_config
 	theme_detect "${1:-}"
 	printf '%s\n' "$THEME_APPEARANCE"
 	exit 0

--- a/scripts/theme/main_spec.sh
+++ b/scripts/theme/main_spec.sh
@@ -364,6 +364,134 @@ EOF
 	End
 
 	#═══════════════════════════════════════════════════════════════
+	# PLUGGABLE DETECTION
+	#═══════════════════════════════════════════════════════════════
+	Describe 'pluggable detection'
+		# These tests verify detection uses user-provided detector functions
+		# from detectors.d/ directory, not hardcoded system detection.
+
+		It 'uses detector function for detection'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/always_dark.sh" << 'EOF'
+theme_detector_always_dark() {
+	THEME_APPEARANCE=dark
+	return 0
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/provider.sh" << 'EOF'
+theme_provider_test() {
+	echo "DETECTED=$1"
+}
+EOF
+			When run script "$BIN"
+			The status should be success
+			The output should equal "DETECTED=dark"
+		End
+
+		It 'tries detectors in alphabetical order until one succeeds'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/aaa_fail.sh" << 'EOF'
+theme_detector_aaa_fail() {
+	return 1
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/bbb_dark.sh" << 'EOF'
+theme_detector_bbb_dark() {
+	THEME_APPEARANCE=dark
+	return 0
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/ccc_light.sh" << 'EOF'
+theme_detector_ccc_light() {
+	THEME_APPEARANCE=light
+	return 0
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/provider.sh" << 'EOF'
+theme_provider_test() {
+	echo "DETECTED=$1"
+}
+EOF
+			When run script "$BIN"
+			The status should be success
+			The output should equal "DETECTED=dark"
+		End
+
+		It 'falls back to THEME env var when no detector succeeds'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/always_fail.sh" << 'EOF'
+theme_detector_always_fail() {
+	return 1
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/provider.sh" << 'EOF'
+theme_provider_test() {
+	echo "SOURCE=$2"
+}
+EOF
+			export THEME=dark
+			When run script "$BIN"
+			The status should be success
+			The output should equal "SOURCE=environment"
+		End
+
+		It 'falls back to light when no detector and no THEME env'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/always_fail.sh" << 'EOF'
+theme_detector_always_fail() {
+	return 1
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/provider.sh" << 'EOF'
+theme_provider_test() {
+	echo "RESULT=$1 SOURCE=$2"
+}
+EOF
+			When run script "$BIN"
+			The status should be success
+			The output should equal "RESULT=light SOURCE=default"
+		End
+
+		It 'sets source to detected when detector succeeds'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/test.sh" << 'EOF'
+theme_detector_test() {
+	THEME_APPEARANCE=dark
+	return 0
+}
+EOF
+			cat > "$XDG_CONFIG_HOME/theme/provider.sh" << 'EOF'
+theme_provider_test() {
+	echo "SOURCE=$2"
+}
+EOF
+			When run script "$BIN"
+			The status should be success
+			The output should equal "SOURCE=detected"
+		End
+
+		It 'shows detectors in --list output'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			cat > "$XDG_CONFIG_HOME/theme/detectors.d/macos.sh" << 'EOF'
+theme_detector_macos() {
+	return 1
+}
+EOF
+			When run script "$BIN" --list
+			The status should be success
+			The output should include "Detectors:"
+			The output should include "theme_detector_macos"
+		End
+
+		It 'shows none found when no detectors configured'
+			mkdir -p "$XDG_CONFIG_HOME/theme/detectors.d"
+			When run script "$BIN" --list
+			The status should be success
+			The output should match pattern "*Detectors:*none found*"
+		End
+	End
+
+	#═══════════════════════════════════════════════════════════════
 	# QUIET MODE
 	#═══════════════════════════════════════════════════════════════
 	Describe 'quiet mode'


### PR DESCRIPTION
## Summary

- Remove hardcoded macOS/Linux/Windows detection, replace with extensible `theme_detector_*` system
- Users provide their own detector functions in `~/.config/theme/detectors.d/`
- Improves testability (39 tests, 0 failures) and allows detection for any system

## Test plan

- [x] All existing tests pass (32 tests)
- [x] New pluggable detection tests pass (7 tests)
- [x] Lint passes