### PR TITLE
fix(templates): update options.sh to match canonical pattern

### DIFF
--- a/templates/options.sh
+++ b/templates/options.sh
@@ -8,6 +8,9 @@ VERSION=0.1.0 # x-release-please-version
 parser_definition() {
 	setup REST help:usage abbr:true -- "Usage: <name> [options]" ''
 	msg -- 'Options:'
-	disp VERSION --version
-	disp :usage -h --help
+	msg -- ''
+	msg -- '  General:'
+	flag    QUIET      -q --quiet           -- "Suppress warnings"
+	disp    :usage     -h --help
+	disp    VERSION    -V --version
 }


### PR DESCRIPTION
## Summary

Updates the script template to match the canonical CLI options pattern used across all scripts.

## Changes

- Add `-V` short flag for `--version`
- Reorder to put help before version (matching other scripts)
- Add "General:" section with `-q/--quiet` flag