### PR TITLE
feat(dotenv): add -o/--override flag to override existing env vars

### DIFF
--- a/dist/dotenv/bin/dotenv
+++ b/dist/dotenv/bin/dotenv
@@ -16,6 +16,7 @@ append_env_file() {
 # URL: https://github.com/ko1nksm/getoptions (v3.3.2)
 ENV_FILES=()
 EXEC_MODE=''
+OVERRIDE=''
 STRICT=''
 QUIET=''
 REST=''
@@ -32,6 +33,10 @@ parse() {
 			case '--exec' in
 				"$1") OPTARG=; break ;;
 				$1*) OPTARG="$OPTARG --exec"
+			esac
+			case '--override' in
+				"$1") OPTARG=; break ;;
+				$1*) OPTARG="$OPTARG --override"
 			esac
 			case '--strict' in
 				"$1") OPTARG=; break ;;
@@ -72,7 +77,7 @@ parse() {
 			-[e]?*) OPTARG=$1; shift
 				eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
 				;;
-			-[xsqhV]?*) OPTARG=$1; shift
+			-[xosqhV]?*) OPTARG=$1; shift
 				eval 'set -- "${OPTARG%"${OPTARG#??}"}" -"${OPTARG#??}"' ${1+'"$@"'}
 				case $2 in --*) set -- "$1" unknown "$2" && REST=x; esac;OPTARG= ;;
 		esac
@@ -86,6 +91,11 @@ parse() {
 				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
 				eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
 				EXEC_MODE="$OPTARG"
+				;;
+			'-o'|'--override')
+				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
+				eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
+				OVERRIDE="$OPTARG"
 				;;
 			'-s'|'--strict')
 				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
@@ -141,6 +151,7 @@ Load environment from .env files and execute command
 Options:
   -e, --env-file FILE         .env file to load (repeatable)
   -x, --exec                  Replace process with exec
+  -o, --override              Override existing environment variables
   -s, --strict                Fail on warnings
 
   General:
@@ -448,7 +459,9 @@ dotenv_exec() {
 	done
 
 	for key in "${!env_vars[@]}"; do
-		[[ -z "${!key+x}" ]] && env_args+=("$key=${env_vars[$key]}")
+		if [[ -n "${DOTENV_OVERRIDE:-}" ]] || [[ -z "${!key+x}" ]]; then
+			env_args+=("$key=${env_vars[$key]}")
+		fi
 	done
 
 	if [[ -n "${DOTENV_EXEC:-}" ]]; then
@@ -472,5 +485,6 @@ fi
 DOTENV_STRICT="$STRICT"
 DOTENV_QUIET="$QUIET"
 DOTENV_EXEC="$EXEC_MODE"
+DOTENV_OVERRIDE="$OVERRIDE"
 
 dotenv_exec "${#ENV_FILES[@]}" "${ENV_FILES[@]}" "$@"

--- a/dist/dotenv/completions/bash/dotenv.bash
+++ b/dist/dotenv/completions/bash/dotenv.bash
@@ -5,7 +5,7 @@ _dotenv() {
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-e --env-file -x --exec -s --strict -q --quiet -h --help -V --version"
+	opts="-e --env-file -x --exec -o --override -s --strict -q --quiet -h --help -V --version"
 
 	# Complete .env files after -e/--env-file
 	if [[ "$prev" == "-e" || "$prev" == "--env-file" ]]; then

--- a/dist/dotenv/completions/zsh/_dotenv
+++ b/dist/dotenv/completions/zsh/_dotenv
@@ -8,6 +8,7 @@ _dotenv() {
 		'(-h --help)'{-h,--help}'[Show help message]' \
 		'(-V --version)'{-V,--version}'[Show version]' \
 		'(-x --exec)'{-x,--exec}'[Replace process with exec]' \
+		'(-o --override)'{-o,--override}'[Override existing environment variables]' \
 		'(-s --strict)'{-s,--strict}'[Fail on warnings]' \
 		'(-q --quiet)'{-q,--quiet}'[Suppress warnings]' \
 		'*'{-e,--env-file}'[Specify .env file to load]:env file:_files -g "*(.)"' \

--- a/dist/dotenv/man/man1/dotenv.1
+++ b/dist/dotenv/man/man1/dotenv.1
@@ -33,16 +33,17 @@ dotenv \- load environment variables from .env files and execute command
 .sp
 \fBdotenv\fP [\fB\-h\fP | \fB\-\-help\fP]
 .br
-\fBdotenv\fP [\fB\-x\fP | \fB\-\-exec\fP] [\fB\-s\fP | \fB\-\-strict\fP] [\fB\-q\fP | \fB\-\-quiet\fP] [\fB\-e\fP \fIFILE\fP].\|.\|. \fICOMMAND\fP [\fIARGS\fP.\|.\|.]
+\fBdotenv\fP [\fB\-x\fP | \fB\-\-exec\fP] [\fB\-o\fP | \fB\-\-override\fP] [\fB\-s\fP | \fB\-\-strict\fP] [\fB\-q\fP | \fB\-\-quiet\fP] [\fB\-e\fP \fIFILE\fP].\|.\|. \fICOMMAND\fP [\fIARGS\fP.\|.\|.]
 .SH "DESCRIPTION"
 .sp
 \fBdotenv\fP loads environment variables from one or more .env files and executes
 a command with the loaded environment. It supports multiline values, quoted
 strings, and comments.
 .sp
-Environment variables that are already set in the calling environment take
-precedence over variables defined in .env files. This allows for easy
-overriding of .env file values.
+By default, environment variables that are already set in the calling
+environment take precedence over variables defined in .env files. Use the
+\fB\-o\fP option to reverse this behavior and have .env file values override the
+calling environment.
 .sp
 The .env file format follows common conventions. For detailed syntax
 information, see \fBenv\fP(5).
@@ -59,6 +60,12 @@ with later files overriding variables from earlier files.
 .RS 4
 Replace the current shell process with the executed command instead of
 running it in a subprocess.
+.RE
+.sp
+\fB\-o\fP, \fB\-\-override\fP
+.RS 4
+Override existing environment variables with values from .env files. By
+default, environment variables already set take precedence over .env values.
 .RE
 .sp
 \fB\-s\fP, \fB\-\-strict\fP
@@ -94,7 +101,7 @@ Arguments to pass to the command.
 .RE
 .SH "VARIABLE PRECEDENCE"
 .sp
-Variables are resolved in the following order (highest to lowest precedence):
+By default, variables are resolved in the following order (highest to lowest):
 .sp
 .RS 4
 .ie n \{\
@@ -121,9 +128,33 @@ Variables from .env files (processed in command\-line order)
 This means that \fBTEST=override dotenv \-e .env command\fP will use "override" as
 the value of TEST, regardless of what .env contains.
 .sp
-When multiple .env files are specified, later files override variables from
-earlier files, but only if those variables are not already set in the
-environment.
+When \fB\-o\fP is specified, .env file values take precedence over the calling
+environment:
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 1." 4.2
+.\}
+Variables from .env files (processed in command\-line order)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 2." 4.2
+.\}
+Environment variables set in the calling shell
+.RE
+.sp
+When multiple .env files are specified, later files always override variables
+from earlier files.
 .if n .sp
 .RS 4
 .it 1 an-trap
@@ -136,8 +167,8 @@ environment.
 .br
 .sp
 An environment variable set to an empty string is still considered "set"
-and will take precedence over .env file values. Use \fBunset VAR\fP to allow the
-\&.env value to be used.
+and will take precedence over .env file values (unless \fB\-o\fP is used). Use
+\fBunset VAR\fP to allow the .env value to be used.
 .sp .5v
 .RE
 .SH "EXAMPLES"
@@ -160,6 +191,11 @@ dotenv \-e .env.local npm start
 Override .env file value with environment variable
 .RS 4
 TEST=override dotenv \-e .env printenv TEST
+.RE
+.sp
+Force .env file values to override existing environment variables
+.RS 4
+TEST=existing dotenv \-o \-e .env printenv TEST
 .RE
 .sp
 Fail if .env.production is missing instead of just warning

--- a/scripts/dotenv/completions/_dotenv
+++ b/scripts/dotenv/completions/_dotenv
@@ -8,6 +8,7 @@ _dotenv() {
 		'(-h --help)'{-h,--help}'[Show help message]' \
 		'(-V --version)'{-V,--version}'[Show version]' \
 		'(-x --exec)'{-x,--exec}'[Replace process with exec]' \
+		'(-o --override)'{-o,--override}'[Override existing environment variables]' \
 		'(-s --strict)'{-s,--strict}'[Fail on warnings]' \
 		'(-q --quiet)'{-q,--quiet}'[Suppress warnings]' \
 		'*'{-e,--env-file}'[Specify .env file to load]:env file:_files -g "*(.)"' \

--- a/scripts/dotenv/completions/dotenv.bash
+++ b/scripts/dotenv/completions/dotenv.bash
@@ -5,7 +5,7 @@ _dotenv() {
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-e --env-file -x --exec -s --strict -q --quiet -h --help -V --version"
+	opts="-e --env-file -x --exec -o --override -s --strict -q --quiet -h --help -V --version"
 
 	# Complete .env files after -e/--env-file
 	if [[ "$prev" == "-e" || "$prev" == "--env-file" ]]; then

--- a/scripts/dotenv/docs/dotenv.adoc
+++ b/scripts/dotenv/docs/dotenv.adoc
@@ -14,7 +14,7 @@ dotenv - load environment variables from .env files and execute command
 == SYNOPSIS
 
 *dotenv* [*-h* | *--help*] +
-*dotenv* [*-x* | *--exec*] [*-s* | *--strict*] [*-q* | *--quiet*] [*-e* _FILE_]... _COMMAND_ [_ARGS_...]
+*dotenv* [*-x* | *--exec*] [*-o* | *--override*] [*-s* | *--strict*] [*-q* | *--quiet*] [*-e* _FILE_]... _COMMAND_ [_ARGS_...]
 
 == DESCRIPTION
 
@@ -22,9 +22,10 @@ dotenv - load environment variables from .env files and execute command
 a command with the loaded environment. It supports multiline values, quoted
 strings, and comments.
 
-Environment variables that are already set in the calling environment take
-precedence over variables defined in .env files. This allows for easy
-overriding of .env file values.
+By default, environment variables that are already set in the calling
+environment take precedence over variables defined in .env files. Use the
+*-o* option to reverse this behavior and have .env file values override the
+calling environment.
 
 The .env file format follows common conventions. For detailed syntax
 information, see *env*(5).
@@ -39,6 +40,10 @@ information, see *env*(5).
 *-x*, *--exec*::
   Replace the current shell process with the executed command instead of
   running it in a subprocess.
+
+*-o*, *--override*::
+  Override existing environment variables with values from .env files. By
+  default, environment variables already set take precedence over .env values.
 
 *-s*, *--strict*::
   Fail with exit code 1 when warnings occur (e.g., missing .env files,
@@ -63,7 +68,7 @@ _ARGS_...::
 
 == VARIABLE PRECEDENCE
 
-Variables are resolved in the following order (highest to lowest precedence):
+By default, variables are resolved in the following order (highest to lowest):
 
 1. Environment variables set in the calling shell
 2. Variables from .env files (processed in command-line order)
@@ -71,13 +76,18 @@ Variables are resolved in the following order (highest to lowest precedence):
 This means that *TEST=override dotenv -e .env command* will use "override" as
 the value of TEST, regardless of what .env contains.
 
-When multiple .env files are specified, later files override variables from
-earlier files, but only if those variables are not already set in the
-environment.
+When *-o* is specified, .env file values take precedence over the calling
+environment:
+
+1. Variables from .env files (processed in command-line order)
+2. Environment variables set in the calling shell
+
+When multiple .env files are specified, later files always override variables
+from earlier files.
 
 NOTE: An environment variable set to an empty string is still considered "set"
-and will take precedence over .env file values. Use *unset VAR* to allow the
-.env value to be used.
+and will take precedence over .env file values (unless *-o* is used). Use
+*unset VAR* to allow the .env value to be used.
 
 == EXAMPLES
 
@@ -96,6 +106,10 @@ Use custom .env file with npm::
 Override .env file value with environment variable::
 
   TEST=override dotenv -e .env printenv TEST
+
+Force .env file values to override existing environment variables::
+
+  TEST=existing dotenv -o -e .env printenv TEST
 
 Fail if .env.production is missing instead of just warning::
 

--- a/scripts/dotenv/dotenv.sh
+++ b/scripts/dotenv/dotenv.sh
@@ -14,7 +14,7 @@ dotenv_warn() {
 
 # Load .env files and execute command using env(1)
 # Usage: dotenv_exec <num_files> file... command [args...]
-# Globals: DOTENV_STRICT, DOTENV_QUIET, DOTENV_EXEC
+# Globals: DOTENV_STRICT, DOTENV_QUIET, DOTENV_EXEC, DOTENV_OVERRIDE
 dotenv_exec() {
 	local num_files=$1
 	shift
@@ -43,9 +43,11 @@ dotenv_exec() {
 		fi
 	done
 
-	# Build env args (skip vars already in environment)
+	# Build env args (skip vars already in environment unless override is set)
 	for key in "${!env_vars[@]}"; do
-		[[ -z "${!key+x}" ]] && env_args+=("$key=${env_vars[$key]}")
+		if [[ -n "${DOTENV_OVERRIDE:-}" ]] || [[ -z "${!key+x}" ]]; then
+			env_args+=("$key=${env_vars[$key]}")
+		fi
 	done
 
 	# Execute with env

--- a/scripts/dotenv/main.sh
+++ b/scripts/dotenv/main.sh
@@ -31,6 +31,7 @@ fi
 DOTENV_STRICT="$STRICT"
 DOTENV_QUIET="$QUIET"
 DOTENV_EXEC="$EXEC_MODE"
+DOTENV_OVERRIDE="$OVERRIDE"
 
 # Load environment and execute command
 dotenv_exec "${#ENV_FILES[@]}" "${ENV_FILES[@]}" "$@"

--- a/scripts/dotenv/main_spec.sh
+++ b/scripts/dotenv/main_spec.sh
@@ -137,6 +137,31 @@ Describe 'dotenv'
 			The status should be success
 			The output should equal "from_env"
 		End
+
+		It 'file values override env with -o flag'
+			echo 'TEST_VAR=from_file' > .env
+			export TEST_VAR=from_env
+			When run script "$BIN" -o printenv TEST_VAR
+			The status should be success
+			The output should equal "from_file"
+		End
+
+		It 'file values override env with --override flag'
+			echo 'TEST_VAR=from_file' > .env
+			export TEST_VAR=from_env
+			When run script "$BIN" --override printenv TEST_VAR
+			The status should be success
+			The output should equal "from_file"
+		End
+
+		It 'override respects file order (later wins)'
+			echo 'TEST_VAR=first' > a.env
+			echo 'TEST_VAR=second' > b.env
+			export TEST_VAR=from_env
+			When run script "$BIN" -o -e a.env -e b.env printenv TEST_VAR
+			The status should be success
+			The output should equal "second"
+		End
 	End
 
 	#═══════════════════════════════════════════════════════════════

--- a/scripts/dotenv/options.sh
+++ b/scripts/dotenv/options.sh
@@ -17,8 +17,9 @@ parser_definition() {
 	msg -- '' 'Load environment from .env files and execute command' ''
 	msg -- 'Options:'
 	param :append_env_file -e --env-file var:FILE init:'ENV_FILES=()' -- ".env file to load (repeatable)"
-	flag  EXEC_MODE -x --exec  -- "Replace process with exec"
-	flag  STRICT    -s --strict -- "Fail on warnings"
+	flag  EXEC_MODE -x --exec     -- "Replace process with exec"
+	flag  OVERRIDE  -o --override -- "Override existing environment variables"
+	flag  STRICT    -s --strict   -- "Fail on warnings"
 	msg -- ''
 	msg -- '  General:'
 	flag  QUIET     -q --quiet -- "Suppress warnings"


### PR DESCRIPTION
## Summary

- Add `-o/--override` flag that reverses the default precedence behavior
- By default, environment variables already set take precedence over .env file values
- With `-o`, .env file values take precedence instead

## Changes

- `options.sh`: Add `-o/--override` flag definition
- `main.sh`: Pass `OVERRIDE` global to `dotenv_exec`
- `dotenv.sh`: Conditionally include all env vars when override is set
- `docs/dotenv.adoc`: Update synopsis, description, options, precedence, and examples
- `completions/`: Add flag to bash and zsh completions
- `main_spec.sh`: Add tests for `-o` and `--override` flags