### PR TITLE
feat(cz): add -m/--{no-}multi-scope flag

### DIFF
--- a/dist/cz/bin/cz
+++ b/dist/cz/bin/cz
@@ -10,6 +10,7 @@ VERSION=0.1.0 # x-release-please-version
 # URL: https://github.com/ko1nksm/getoptions (v3.3.2)
 CONFIG_FILE=''
 unset REQUIRE_SCOPE ||:
+unset MULTI_SCOPE ||:
 QUIET=''
 REST=''
 parse() {
@@ -29,6 +30,14 @@ parse() {
 			case '--no-require-scope' in
 				"$1") OPTARG=; break ;;
 				$1*) OPTARG="$OPTARG --no-require-scope"
+			esac
+			case '--multi-scope' in
+				"$1") OPTARG=; break ;;
+				$1*) OPTARG="$OPTARG --multi-scope"
+			esac
+			case '--no-multi-scope' in
+				"$1") OPTARG=; break ;;
+				$1*) OPTARG="$OPTARG --no-multi-scope"
 			esac
 			case '--quiet' in
 				"$1") OPTARG=; break ;;
@@ -65,7 +74,7 @@ parse() {
 			-[c]?*) OPTARG=$1; shift
 				eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
 				;;
-			-[rqhV]?*) OPTARG=$1; shift
+			-[rmqhV]?*) OPTARG=$1; shift
 				eval 'set -- "${OPTARG%"${OPTARG#??}"}" -"${OPTARG#??}"' ${1+'"$@"'}
 				case $2 in --*) set -- "$1" unknown "$2" && REST=x; esac;OPTARG= ;;
 		esac
@@ -79,6 +88,11 @@ parse() {
 				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
 				eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
 				REQUIRE_SCOPE="$OPTARG"
+				;;
+			'-m'|'--multi-scope'|'--no-multi-scope')
+				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
+				eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
+				MULTI_SCOPE="$OPTARG"
 				;;
 			'-q'|'--quiet')
 				[ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
@@ -131,6 +145,7 @@ Conventional commit message builder
 Options:
   -c, --config-file FILE      Config file path
   -r, --{no-}require-scope    Require scope (create: mandatory, lint: enforce for scoped files)
+  -m, --{no-}multi-scope      Allow multiple scopes like feat(api,db):
   -q, --quiet                 Suppress warnings and non-essential output
   -h, --help                  
   -V, --version               
@@ -654,7 +669,7 @@ get_files_to_validate() {
 is_multi_scope() { [[ "$1" == *"$(_get_sep)"* ]]; }
 
 validate_paths_if_needed() {
-	local scope="$1" require_scope
+	local scope="$1" require_scope multi_scope
 
 	if [[ "${REQUIRE_SCOPE-unset}" == "1" ]]; then
 		require_scope=true
@@ -662,6 +677,14 @@ validate_paths_if_needed() {
 		require_scope=false
 	else
 		require_scope="${CFG_SETTINGS[require_scope]:-false}"
+	fi
+
+	if [[ "${MULTI_SCOPE-unset}" == "1" ]]; then
+		multi_scope=true
+	elif [[ "${MULTI_SCOPE-unset}" == "" ]]; then
+		multi_scope=false
+	else
+		multi_scope="${CFG_SETTINGS[multi_scope]:-false}"
 	fi
 
 	if [[ "$require_scope" == "true" && -n "$scope" ]]; then
@@ -696,9 +719,9 @@ validate_paths_if_needed() {
 	[[ "$scope" == "*" ]] && return 0
 
 	if is_multi_scope "$scope"; then
-		[[ "${CFG_SETTINGS[multi_scope]:-false}" != "true" ]] && {
-			_err "multi-scope not enabled in config"
-			_hint "Set multi-scope = true in [settings] to use multiple scopes"
+		[[ "$multi_scope" != "true" ]] && {
+			_err "multi-scope not enabled"
+			_hint "Use --multi-scope flag or set multi-scope = true in [settings]"
 			return 1
 		}
 		_check_scopes_exist "$scope" || return 1

--- a/dist/cz/completions/bash/cz.bash
+++ b/dist/cz/completions/bash/cz.bash
@@ -7,7 +7,7 @@ _cz() {
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 	local commands="create lint parse init hook"
-	local global_opts="-c --config-file -q --quiet -h --help -V --version"
+	local global_opts="-c --config-file -r --require-scope --no-require-scope -m --multi-scope --no-multi-scope -q --quiet -h --help -V --version"
 
 	# Complete config file path after -c/--config-file
 	if [[ "$prev" == "-c" || "$prev" == "--config-file" ]]; then
@@ -36,13 +36,13 @@ _cz() {
 	else
 		case "$cmd" in
 			create)
-				mapfile -t COMPREPLY < <(compgen -W "-s --strict-scopes -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "--custom-scope --no-custom-scope -h --help" -- "$cur")
 				;;
 			lint)
-				mapfile -t COMPREPLY < <(compgen -W "-p --paths -s --strict --no-strict -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "-p --paths -h --help" -- "$cur")
 				;;
 			init)
-				mapfile -t COMPREPLY < <(compgen -W "-f --force -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "-o --output -f --force -h --help" -- "$cur")
 				;;
 			hook)
 				mapfile -t COMPREPLY < <(compgen -W "install uninstall status -h --help" -- "$cur")

--- a/dist/cz/completions/zsh/_cz
+++ b/dist/cz/completions/zsh/_cz
@@ -8,6 +8,10 @@ _cz() {
 		'(-h --help)'{-h,--help}'[Show help message]' \
 		'(-V --version)'{-V,--version}'[Show version]' \
 		'(-c --config-file)'{-c,--config-file}'[Config file path]:config file:_files' \
+		'(-r --require-scope --no-require-scope)'{-r,--require-scope}'[Require scope]' \
+		'(-r --require-scope --no-require-scope)--no-require-scope[Disable scope requirement]' \
+		'(-m --multi-scope --no-multi-scope)'{-m,--multi-scope}'[Allow multiple scopes]' \
+		'(-m --multi-scope --no-multi-scope)--no-multi-scope[Disallow multiple scopes]' \
 		'(-q --quiet)'{-q,--quiet}'[Suppress warnings and non-essential output]' \
 		'1:command:->commands' \
 		'*::arg:->args'
@@ -28,14 +32,13 @@ _cz() {
 				create)
 					_arguments \
 						'(-h --help)'{-h,--help}'[Show help message]' \
-						'(-s --strict-scopes)'{-s,--strict-scopes}'[Only allow configured scopes]'
+						'(--custom-scope --no-custom-scope)--custom-scope[Allow free-form scope input]' \
+						'(--custom-scope --no-custom-scope)--no-custom-scope[Only allow configured scopes]'
 					;;
 				lint)
 					_arguments \
 						'(-h --help)'{-h,--help}'[Show help message]' \
-						'(-p --paths)'{-p,--paths}'[Validate scope against file paths]:files:_files' \
-						'(-s --strict)'{-s,--strict}'[Require scope for scoped files]' \
-						'--no-strict[Allow missing scope]'
+						'(-p --paths)'{-p,--paths}'[Validate scope against file paths]:files:_files'
 					;;
 				init)
 					_arguments \

--- a/dist/cz/man/man1/cz.1
+++ b/dist/cz/man/man1/cz.1
@@ -31,7 +31,7 @@
 cz \- conventional commit message builder
 .SH "SYNOPSIS"
 .sp
-\fBcz\fP [\fB\-r\fP | \fB\-\-no\-require\-scope\fP] [\fB\-q\fP] [\fB\-c\fP \fIFILE\fP] [\fISUBCOMMAND\fP]
+\fBcz\fP [\fB\-r\fP | \fB\-\-no\-require\-scope\fP] [\fB\-m\fP | \fB\-\-no\-multi\-scope\fP] [\fB\-q\fP] [\fB\-c\fP \fIFILE\fP] [\fISUBCOMMAND\fP]
 .sp
 \fBcz\fP \fBcreate\fP [\fB\-\-custom\-scope\fP | \fB\-\-no\-custom\-scope\fP]
 .br
@@ -140,6 +140,19 @@ without scope in \fBlint\fP even when files match scope patterns. Overrides
 the \f(CRrequire\-scope\fP setting in the configuration file.
 .RE
 .sp
+\fB\-m\fP, \fB\-\-multi\-scope\fP
+.RS 4
+Allow multiple scopes in a commit like \f(CRfeat(api,db):\fP. Overrides the
+\f(CRmulti\-scope\fP setting in the configuration file.
+.RE
+.sp
+\fB\-\-no\-multi\-scope\fP
+.RS 4
+Disallow multiple scopes. Commits with multiple scopes like \f(CRfeat(api,db):\fP
+will fail validation. Overrides the \f(CRmulti\-scope\fP setting in the
+configuration file.
+.RE
+.sp
 \fB\-q\fP, \fB\-\-quiet\fP
 .RS 4
 Suppress warnings and non\-essential output.
@@ -245,8 +258,9 @@ T}
 .TE
 .sp
 .sp
-The config setting \f(CRrequire\-scope = true\fP in \f(CR[settings]\fP has the same effect as
-\fB\-\-require\-scope\fP, but CLI flags override the config setting.
+The config settings \f(CRrequire\-scope = true\fP and \f(CRmulti\-scope = true\fP in \f(CR[settings]\fP
+have the same effect as their corresponding CLI flags, but CLI flags always
+override config settings.
 .SH "EXAMPLES"
 .sp
 Create and commit interactively
@@ -282,6 +296,11 @@ echo "feat(api): add endpoint" | cz lint \-\-paths "src/api/routes.ts"
 Lint with required scope for scoped files
 .RS 4
 cz \-\-require\-scope lint \-\-paths "$(git diff \-\-cached \-\-name\-only)" < "$1"
+.RE
+.sp
+Lint with multi\-scope enabled
+.RS 4
+echo "feat(api,db): cross\-cutting change" | cz \-\-multi\-scope lint
 .RE
 .sp
 Show resolved configuration

--- a/scripts/cz/cmd_lint.sh
+++ b/scripts/cz/cmd_lint.sh
@@ -101,7 +101,7 @@ is_multi_scope() { [[ "$1" == *"$(_get_sep)"* ]]; }
 # Validate paths against scope(s) if INI format and files provided
 # Usage: validate_paths_if_needed <scope>
 validate_paths_if_needed() {
-	local scope="$1" require_scope
+	local scope="$1" require_scope multi_scope
 
 	# Determine require-scope mode (--require-scope/--no-require-scope override config)
 	if [[ "${REQUIRE_SCOPE-unset}" == "1" ]]; then
@@ -110,6 +110,15 @@ validate_paths_if_needed() {
 		require_scope=false
 	else
 		require_scope="${CFG_SETTINGS[require_scope]:-false}"
+	fi
+
+	# Determine multi-scope mode (--multi-scope/--no-multi-scope override config)
+	if [[ "${MULTI_SCOPE-unset}" == "1" ]]; then
+		multi_scope=true
+	elif [[ "${MULTI_SCOPE-unset}" == "" ]]; then
+		multi_scope=false
+	else
+		multi_scope="${CFG_SETTINGS[multi_scope]:-false}"
 	fi
 
 	# In require-scope mode with scope, validate scope exists
@@ -149,9 +158,9 @@ validate_paths_if_needed() {
 
 	# Multi-scope validation
 	if is_multi_scope "$scope"; then
-		[[ "${CFG_SETTINGS[multi_scope]:-false}" != "true" ]] && {
-			_err "multi-scope not enabled in config"
-			_hint "Set multi-scope = true in [settings] to use multiple scopes"
+		[[ "$multi_scope" != "true" ]] && {
+			_err "multi-scope not enabled"
+			_hint "Use --multi-scope flag or set multi-scope = true in [settings]"
 			return 1
 		}
 		_check_scopes_exist "$scope" || return 1

--- a/scripts/cz/completions/_cz
+++ b/scripts/cz/completions/_cz
@@ -8,6 +8,10 @@ _cz() {
 		'(-h --help)'{-h,--help}'[Show help message]' \
 		'(-V --version)'{-V,--version}'[Show version]' \
 		'(-c --config-file)'{-c,--config-file}'[Config file path]:config file:_files' \
+		'(-r --require-scope --no-require-scope)'{-r,--require-scope}'[Require scope]' \
+		'(-r --require-scope --no-require-scope)--no-require-scope[Disable scope requirement]' \
+		'(-m --multi-scope --no-multi-scope)'{-m,--multi-scope}'[Allow multiple scopes]' \
+		'(-m --multi-scope --no-multi-scope)--no-multi-scope[Disallow multiple scopes]' \
 		'(-q --quiet)'{-q,--quiet}'[Suppress warnings and non-essential output]' \
 		'1:command:->commands' \
 		'*::arg:->args'
@@ -28,14 +32,13 @@ _cz() {
 				create)
 					_arguments \
 						'(-h --help)'{-h,--help}'[Show help message]' \
-						'(-s --strict-scopes)'{-s,--strict-scopes}'[Only allow configured scopes]'
+						'(--custom-scope --no-custom-scope)--custom-scope[Allow free-form scope input]' \
+						'(--custom-scope --no-custom-scope)--no-custom-scope[Only allow configured scopes]'
 					;;
 				lint)
 					_arguments \
 						'(-h --help)'{-h,--help}'[Show help message]' \
-						'(-p --paths)'{-p,--paths}'[Validate scope against file paths]:files:_files' \
-						'(-s --strict)'{-s,--strict}'[Require scope for scoped files]' \
-						'--no-strict[Allow missing scope]'
+						'(-p --paths)'{-p,--paths}'[Validate scope against file paths]:files:_files'
 					;;
 				init)
 					_arguments \

--- a/scripts/cz/completions/cz.bash
+++ b/scripts/cz/completions/cz.bash
@@ -7,7 +7,7 @@ _cz() {
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 	local commands="create lint parse init hook"
-	local global_opts="-c --config-file -q --quiet -h --help -V --version"
+	local global_opts="-c --config-file -r --require-scope --no-require-scope -m --multi-scope --no-multi-scope -q --quiet -h --help -V --version"
 
 	# Complete config file path after -c/--config-file
 	if [[ "$prev" == "-c" || "$prev" == "--config-file" ]]; then
@@ -36,13 +36,13 @@ _cz() {
 	else
 		case "$cmd" in
 			create)
-				mapfile -t COMPREPLY < <(compgen -W "-s --strict-scopes -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "--custom-scope --no-custom-scope -h --help" -- "$cur")
 				;;
 			lint)
-				mapfile -t COMPREPLY < <(compgen -W "-p --paths -s --strict --no-strict -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "-p --paths -h --help" -- "$cur")
 				;;
 			init)
-				mapfile -t COMPREPLY < <(compgen -W "-f --force -h --help" -- "$cur")
+				mapfile -t COMPREPLY < <(compgen -W "-o --output -f --force -h --help" -- "$cur")
 				;;
 			hook)
 				mapfile -t COMPREPLY < <(compgen -W "install uninstall status -h --help" -- "$cur")

--- a/scripts/cz/docs/cz.adoc
+++ b/scripts/cz/docs/cz.adoc
@@ -13,7 +13,7 @@ cz - conventional commit message builder
 
 == SYNOPSIS
 
-*cz* [*-r* | *--no-require-scope*] [*-q*] [*-c* _FILE_] [_SUBCOMMAND_]
+*cz* [*-r* | *--no-require-scope*] [*-m* | *--no-multi-scope*] [*-q*] [*-c* _FILE_] [_SUBCOMMAND_]
 
 *cz* *create* [*--custom-scope* | *--no-custom-scope*] +
 *cz* *lint* [*-p* _PATHS_] +
@@ -101,6 +101,15 @@ in a terminal, or *lint* mode if receiving input on standard input.
   without scope in *lint* even when files match scope patterns. Overrides
   the `require-scope` setting in the configuration file.
 
+*-m*, *--multi-scope*::
+  Allow multiple scopes in a commit like `feat(api,db):`. Overrides the
+  `multi-scope` setting in the configuration file.
+
+*--no-multi-scope*::
+  Disallow multiple scopes. Commits with multiple scopes like `feat(api,db):`
+  will fail validation. Overrides the `multi-scope` setting in the
+  configuration file.
+
 *-q*, *--quiet*::
   Suppress warnings and non-essential output.
 
@@ -154,8 +163,9 @@ The *--require-scope* option also affects the *lint* command:
 |Allows no scope even for scoped files
 |===
 
-The config setting `require-scope = true` in `[settings]` has the same effect as
-*--require-scope*, but CLI flags override the config setting.
+The config settings `require-scope = true` and `multi-scope = true` in `[settings]`
+have the same effect as their corresponding CLI flags, but CLI flags always
+override config settings.
 
 == EXAMPLES
 
@@ -186,6 +196,10 @@ Lint with scope validation against specific files::
 Lint with required scope for scoped files::
 
   cz --require-scope lint --paths "$(git diff --cached --name-only)" < "$1"
+
+Lint with multi-scope enabled::
+
+  echo "feat(api,db): cross-cutting change" | cz --multi-scope lint
 
 Show resolved configuration::
 

--- a/scripts/cz/main_spec.sh
+++ b/scripts/cz/main_spec.sh
@@ -490,6 +490,52 @@ EOF
 				When run script "$BIN" lint --paths "src/api/handler.go src/ui/button.tsx"
 				The status should be success
 			End
+
+			It '--multi-scope flag enables multi-scope without config'
+				cat > .gitcommitizen << 'EOF'
+[types]
+feat = Feature
+
+[scopes]
+api = src/api/**
+ui = src/ui/**
+EOF
+				Data "feat(api,ui): cross-cutting change"
+				When run script "$BIN" --multi-scope lint --paths "src/api/handler.go src/ui/button.tsx"
+				The status should be success
+			End
+
+			It '--no-multi-scope flag disables multi-scope even with config'
+				cat > .gitcommitizen << 'EOF'
+[settings]
+multi-scope = true
+
+[types]
+feat = Feature
+
+[scopes]
+api = src/api/**
+ui = src/ui/**
+EOF
+				Data "feat(api,ui): cross-cutting change"
+				When run script "$BIN" --no-multi-scope lint --paths "src/api/x.go"
+				The status should be failure
+				The stderr should include "multi-scope not enabled"
+			End
+
+			It '-m shorthand enables multi-scope'
+				cat > .gitcommitizen << 'EOF'
+[types]
+feat = Feature
+
+[scopes]
+api = src/api/**
+ui = src/ui/**
+EOF
+				Data "feat(api,ui): cross-cutting change"
+				When run script "$BIN" -m lint --paths "src/api/handler.go src/ui/button.tsx"
+				The status should be success
+			End
 		End
 
 		#───────────────────────────────────────────────────────────

--- a/scripts/cz/options.sh
+++ b/scripts/cz/options.sh
@@ -11,6 +11,7 @@ parser_definition() {
 	msg -- 'Options:'
 	param   CONFIG_FILE   -c --config-file var:FILE -- "Config file path"
 	flag    REQUIRE_SCOPE -r --{no-}require-scope init:@unset -- "Require scope (create: mandatory, lint: enforce for scoped files)"
+	flag    MULTI_SCOPE   -m --{no-}multi-scope   init:@unset -- "Allow multiple scopes like feat(api,db):"
 	flag    QUIET         -q --quiet       -- "Suppress warnings and non-essential output"
 	disp    :usage        -h --help
 	disp    VERSION       -V --version


### PR DESCRIPTION
## Summary

- Add `-m/--multi-scope` and `--no-multi-scope` CLI flags
- Flags override the `multi-scope` config setting, like `--require-scope` does
- Fix outdated shell completions to use current flag names

## Changes

- `options.sh`: Add `-m/--{no-}multi-scope` global flag
- `cmd_lint.sh`: Check `MULTI_SCOPE` flag before falling back to config
- `docs/cz.adoc`: Document new flags with examples
- `completions/`: Update bash/zsh completions with all current flags
- `main_spec.sh`: Add tests for `--multi-scope`, `--no-multi-scope`, and `-m`