### PR TITLE
ci: add completions sync validation

### DIFF
--- a/.github/workflows/scripts-ci.yaml
+++ b/.github/workflows/scripts-ci.yaml
@@ -76,6 +76,17 @@ jobs:
           echo "scripts=$scripts" >> "$GITHUB_OUTPUT"
           echo "Scripts: $scripts"
 
+  completions-sync:
+    name: Completions sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+
+      - name: Check completions match options.sh
+        run: nix develop --command ./utils/check-completions.sh
+
   ci:
     name: ${{ matrix.script }}
     needs: detect-changes

--- a/utils/check-completions.sh
+++ b/utils/check-completions.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Validate that shell completions match options.sh definitions
+# Exit 0 if all completions are in sync, 1 if mismatches found
+
+set -euo pipefail
+
+# shellcheck disable=SC2034 # VERSION used by getoptions disp
+VERSION=0.1.0
+
+parser_definition() {
+	setup REST help:usage abbr:true -- \
+		"Usage: check-completions.sh [options] [script_dir...]" \
+		'' \
+		'Validate that shell completions match options.sh definitions.' \
+		'If no directories specified, checks all scripts/* directories.' \
+		''
+	msg -- 'Options:'
+	disp :usage -h --help
+	disp VERSION -V --version
+}
+
+eval "$(getoptions parser_definition parse)"
+parse "$@"
+eval "set -- $REST"
+
+# Extract flags from options.sh parser definitions
+# Handles: flag, param, disp, option with -x --long --{no-}pattern
+extract_options_flags() {
+	local file="$1"
+	local parser="${2:-parser_definition}"
+
+	# Look for flag/param/disp/option lines within the parser function
+	# Extract -x and --long-flag patterns
+	awk -v parser="$parser" '
+		# Track when we are inside the target parser function
+		$0 ~ "^" parser "\\(\\)" { in_parser = 1; next }
+		$0 ~ "^parser_definition" && in_parser { in_parser = 0 }
+		$0 ~ "^}" && in_parser { in_parser = 0 }
+
+		in_parser && /^\t(flag|param|disp|option)/ {
+			# Extract all -X and --word patterns from the line
+			for (i = 1; i <= NF; i++) {
+				if ($i ~ /^-[a-zA-Z]$/) {
+					print $i
+				} else if ($i ~ /^--\{no-\}/) {
+					# --{no-}foo expands to --foo and --no-foo
+					gsub(/--\{no-\}/, "", $i)
+					print "--" $i
+					print "--no-" $i
+				} else if ($i ~ /^--[a-z]/) {
+					# Remove trailing patterns like var:FILE
+					gsub(/:.*$/, "", $i)
+					# Stop at -- which separates flags from description
+					if ($i == "--") break
+					print $i
+				}
+			}
+		}
+	' "$file" | sort -u
+}
+
+# Extract flags from bash completion file
+extract_completion_flags() {
+	local file="$1"
+
+	# Look for quoted strings containing flag lists (opts="..." or compgen -W "...")
+	# Extract flags from within those quoted strings only
+	grep -oE '"[^"]*"' "$file" 2>/dev/null |
+		tr -d '"' |
+		tr ' ' '\n' |
+		grep -oE -- '^-[a-zA-Z]$|^--[a-z][-a-z]*$' |
+		sort -u
+}
+
+# Compare two flag lists
+# Usage: compare_flags <options_flags> <completion_flags>
+compare_flags() {
+	local options_flags="$1"
+	local completion_flags="$2"
+
+	local missing_in_completion missing_in_options
+	missing_in_completion=$(comm -23 <(echo "$options_flags") <(echo "$completion_flags"))
+	missing_in_options=$(comm -13 <(echo "$options_flags") <(echo "$completion_flags"))
+
+	local has_error=0
+
+	if [[ -n "$missing_in_completion" ]]; then
+		echo "  Missing in completions:"
+		while IFS= read -r line; do
+			echo "    $line"
+		done <<<"$missing_in_completion"
+		has_error=1
+	fi
+
+	if [[ -n "$missing_in_options" ]]; then
+		echo "  Extra in completions (not in options.sh):"
+		while IFS= read -r line; do
+			echo "    $line"
+		done <<<"$missing_in_options"
+		has_error=1
+	fi
+
+	return $has_error
+}
+
+# Check a single script directory
+check_script() {
+	local script_dir="$1"
+	script_dir="${script_dir%/}" # Remove trailing slash
+
+	local script_name options_file bash_completion
+	script_name=$(basename "$script_dir")
+	options_file="$script_dir/options.sh"
+	bash_completion="$script_dir/completions/${script_name}.bash"
+
+	# Skip if no options.sh
+	[[ -f "$options_file" ]] || return 0
+
+	echo "Checking $script_name..."
+
+	# Check bash completion
+	if [[ -f "$bash_completion" ]]; then
+		local options_flags completion_flags parsers
+
+		# Get all parser definitions in the file
+		parsers=$(grep -oE '^parser_definition[_a-z]*' "$options_file" | sort -u)
+
+		# Collect flags from all parsers
+		options_flags=""
+		while IFS= read -r parser; do
+			options_flags+="$(extract_options_flags "$options_file" "$parser")"$'\n'
+		done <<<"$parsers"
+		options_flags=$(echo "$options_flags" | grep -v '^$' | sort -u)
+
+		completion_flags=$(extract_completion_flags "$bash_completion")
+
+		if ! compare_flags "$options_flags" "$completion_flags"; then
+			return 1
+		fi
+	else
+		echo "  No bash completion file found"
+	fi
+
+	return 0
+}
+
+main() {
+	local exit_code=0
+	local script_dirs=("$@")
+
+	# Default to scripts/* if no arguments
+	if [[ ${#script_dirs[@]} -eq 0 ]]; then
+		for d in scripts/*/; do
+			[[ -d "$d" ]] && script_dirs+=("$d")
+		done
+	fi
+
+	for script_dir in "${script_dirs[@]}"; do
+		if ! check_script "$script_dir"; then
+			exit_code=1
+		fi
+	done
+
+	if [[ $exit_code -eq 0 ]]; then
+		echo "All completions in sync!"
+	else
+		echo ""
+		echo "Completion files are out of sync with options.sh"
+	fi
+
+	return $exit_code
+}
+
+main "$@"

--- a/utils/check-completions_spec.sh
+++ b/utils/check-completions_spec.sh
@@ -1,0 +1,248 @@
+# shellcheck shell=bash
+
+Describe 'check-completions.sh'
+	setup() {
+		TEST_DIR=$(mktemp -d)
+	}
+
+	cleanup() {
+		rm -rf "$TEST_DIR"
+	}
+
+	BeforeEach 'setup'
+	AfterEach 'cleanup'
+
+	create_script() {
+		local name="$1"
+		mkdir -p "$TEST_DIR/$name/completions"
+	}
+
+	create_options() {
+		local name="$1"
+		local content="$2"
+		echo "$content" > "$TEST_DIR/$name/options.sh"
+	}
+
+	create_completion() {
+		local name="$1"
+		local content="$2"
+		echo "$content" > "$TEST_DIR/$name/completions/${name}.bash"
+	}
+
+	Describe 'when completions are in sync'
+		It 'exits 0 with simple flags'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+	param   PARAM   -p --param
+	disp    :usage  -h --help
+}'
+			create_completion "foo" '
+opts="-f --flag -p --param -h --help"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should include "All completions in sync!"
+		End
+
+		It 'handles --{no-} pattern flags'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    VERBOSE -v --{no-}verbose
+}'
+			create_completion "foo" '
+opts="-v --verbose --no-verbose"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should include "All completions in sync!"
+		End
+
+		It 'handles multiple parser definitions'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    GLOBAL  -g --global
+	cmd     sub
+}
+
+parser_definition_sub() {
+	flag    LOCAL   -l --local
+}'
+			create_completion "foo" '
+global_opts="-g --global"
+sub_opts="-l --local"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should include "All completions in sync!"
+		End
+	End
+
+	Describe 'when completions are missing flags'
+		It 'exits 1 and reports missing flags'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+	param   PARAM   -p --param
+}'
+			create_completion "foo" '
+opts="-f --flag"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be failure
+			The output should include "Missing in completions:"
+			The output should include "--param"
+			The output should include "-p"
+		End
+	End
+
+	Describe 'when completions have extra flags'
+		It 'exits 1 and reports extra flags'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+}'
+			create_completion "foo" '
+opts="-f --flag -x --extra"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be failure
+			The output should include "Extra in completions"
+			The output should include "--extra"
+			The output should include "-x"
+		End
+	End
+
+	Describe 'when completion file is missing'
+		It 'reports no completion file found'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+}'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The output should include "No bash completion file found"
+		End
+	End
+
+	Describe 'when options.sh is missing'
+		It 'skips the script directory'
+			mkdir -p "$TEST_DIR/scripts/foo/completions"
+			echo 'opts="-f --flag"' > "$TEST_DIR/scripts/foo/completions/foo.bash"
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should not include "foo"
+		End
+	End
+
+	Describe 'flag extraction'
+		It 'ignores var: suffixes on params'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	param   FILE    -f --file var:PATH
+}'
+			create_completion "foo" '
+opts="-f --file"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should include "All completions in sync!"
+		End
+
+		It 'handles disp with function reference'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	disp    :usage  -h --help
+	disp    VERSION -V --version
+}'
+			create_completion "foo" '
+opts="-h --help -V --version"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo"
+			The status should be success
+			The output should include "All completions in sync!"
+		End
+	End
+
+	Describe 'multiple scripts'
+		It 'checks all scripts and reports each'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+}'
+			create_completion "foo" '
+opts="-f --flag"
+'
+
+			create_script "bar"
+			create_options "bar" '
+parser_definition() {
+	flag    FLAG    -b --bar
+}'
+			create_completion "bar" '
+opts="-b --bar"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo" "$TEST_DIR/bar"
+			The status should be success
+			The output should include "Checking foo"
+			The output should include "Checking bar"
+		End
+
+		It 'fails if any script is out of sync'
+			create_script "foo"
+			create_options "foo" '
+parser_definition() {
+	flag    FLAG    -f --flag
+}'
+			create_completion "foo" '
+opts="-f --flag"
+'
+
+			create_script "bar"
+			create_options "bar" '
+parser_definition() {
+	flag    FLAG    -b --bar
+}'
+			create_completion "bar" '
+opts="-x --wrong"
+'
+
+			When run script ./check-completions.sh "$TEST_DIR/foo" "$TEST_DIR/bar"
+			The status should be failure
+			The output should include "Completion files are out of sync"
+		End
+	End
+
+	Describe 'CLI options'
+		It 'shows help with -h'
+			When run script ./check-completions.sh -h
+			The status should be success
+			The output should include 'Usage:'
+			The output should include 'script_dir'
+		End
+
+		It 'shows version with -V'
+			When run script ./check-completions.sh -V
+			The status should be success
+			The output should match pattern '*.*.*'
+		End
+	End
+End


### PR DESCRIPTION
## Summary

- Add CI workflow to detect when shell completions fall out of sync with options.sh
- Add validation script that extracts flags from parser definitions and compares against completion files
- Catches stale options (like `--strict-scopes` in cz) and missing new options

## Changes

- `utils/check-completions.sh` - Validation script that:
  - Parses all `parser_definition*` functions in options.sh
  - Extracts flags (`-x`, `--long`, `--{no-}pattern`)
  - Compares against flags in bash completion files
  - Reports mismatches with clear output

- `.github/workflows/completions-sync.yaml` - Triggers on changes to:
  - `scripts/*/options.sh`
  - `scripts/*/completions/*`
  - `utils/check-completions.sh`

## Note

This CI check will fail until cz completions are updated (they reference old `--strict-scopes` and `--strict` flags). That's expected - the check is working correctly.