### PR TITLE
fix(ci): only check completions for changed scripts

### DIFF
--- a/.github/workflows/scripts-ci.yaml
+++ b/.github/workflows/scripts-ci.yaml
@@ -78,6 +78,8 @@ jobs:
 
   completions-sync:
     name: Completions sync
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scripts != '[]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +87,12 @@ jobs:
       - uses: cachix/install-nix-action@v30
 
       - name: Check completions match options.sh
-        run: nix develop --command ./utils/check-completions.sh
+        run: |
+          scripts='${{ needs.detect-changes.outputs.scripts }}'
+          # Convert JSON array to space-separated paths: ["cz","jwt"] -> scripts/cz scripts/jwt
+          script_dirs=$(echo "$scripts" | jq -r '.[] | "scripts/\(.)"' | tr '\n' ' ')
+          echo "Checking: $script_dirs"
+          nix develop --command ./utils/check-completions.sh $script_dirs
 
   ci:
     name: ${{ matrix.script }}


### PR DESCRIPTION
## Summary

- Optimize completions-sync CI job to only check changed scripts instead of all
- Uses detect-changes output to determine which scripts were modified

## Changes

Before: `./utils/check-completions.sh` (checks all scripts)
After: `./utils/check-completions.sh scripts/cz scripts/jwt` (only changed)