### PR TITLE
fix(ci): move completions-sync into template workflow

### DIFF
--- a/.github/workflows/_template.scripts-ci.yaml
+++ b/.github/workflows/_template.scripts-ci.yaml
@@ -141,3 +141,14 @@ jobs:
             exit 1
           fi
           echo "✅ Artifacts are up to date."
+
+  completions-sync:
+    name: Completions sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+
+      - name: Check completions match options.sh
+        run: nix develop --command ./utils/check-completions.sh scripts/${{ inputs.script }}

--- a/.github/workflows/scripts-ci.yaml
+++ b/.github/workflows/scripts-ci.yaml
@@ -76,24 +76,6 @@ jobs:
           echo "scripts=$scripts" >> "$GITHUB_OUTPUT"
           echo "Scripts: $scripts"
 
-  completions-sync:
-    name: Completions sync
-    needs: detect-changes
-    if: needs.detect-changes.outputs.scripts != '[]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: cachix/install-nix-action@v30
-
-      - name: Check completions match options.sh
-        run: |
-          scripts='${{ needs.detect-changes.outputs.scripts }}'
-          # Convert JSON array to space-separated paths: ["cz","jwt"] -> scripts/cz scripts/jwt
-          script_dirs=$(echo "$scripts" | jq -r '.[] | "scripts/\(.)"' | tr '\n' ' ')
-          echo "Checking: $script_dirs"
-          nix develop --command ./utils/check-completions.sh $script_dirs
-
   ci:
     name: ${{ matrix.script }}
     needs: detect-changes


### PR DESCRIPTION
## Summary
- Moves completions-sync job into the template workflow
- Shows as "cz / Completions sync" alongside other per-script jobs instead of standalone

## Changes
- Add completions-sync job to `_template.scripts-ci.yaml`
- Remove standalone completions-sync job from `scripts-ci.yaml`